### PR TITLE
feat(youtube): add toggle method

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -246,6 +246,7 @@ export namespace Components {
     'pause': () => Promise<void>;
     'play': () => Promise<void>;
     'src': string;
+    'toggle': () => Promise<void>;
     'width': number;
   }
   interface DeckgoSlideYoutubeAttributes extends StencilHTMLAttributes {

--- a/src/components/slides/deckdeckgo-slide-youtube/deckdeckgo-slide-youtube.tsx
+++ b/src/components/slides/deckdeckgo-slide-youtube/deckdeckgo-slide-youtube.tsx
@@ -21,6 +21,7 @@ export class DeckdeckgoSlideYoutube implements DeckdeckgoSlide {
   @State() videoWidth: number;
   @State() videoHeight: number;
 
+  @State() isPlaying = false;
   @State() frameTitle: string;
 
   async componentDidLoad() {
@@ -73,7 +74,17 @@ export class DeckdeckgoSlideYoutube implements DeckdeckgoSlide {
     await this.playPauseVideo(false);
   }
 
-  private playPauseVideo(play: boolean): Promise<void> {
+  @Method()
+  async toggle() {
+    await this.playPauseVideo();
+  }
+
+  private playPauseVideo(play?: boolean): Promise<void> {
+    if (typeof play === 'undefined') {
+      play = !this.isPlaying;
+    }
+    this.isPlaying = play;
+
     return new Promise<void>(async (resolve) => {
       const element: HTMLDeckgoYoutubeElement = this.el.shadowRoot.querySelector('deckgo-youtube');
 

--- a/src/index.html
+++ b/src/index.html
@@ -179,7 +179,7 @@ public static void main(String args[]) {
     }
   }
 
-  function playVideo() {
+  function toggleVideo() {
     return new Promise(async (resolve) => {
       const deck = document.getElementById('slider');
 
@@ -197,7 +197,7 @@ public static void main(String args[]) {
         return;
       }
 
-      await youtubeSlideElement.play();
+      await youtubeSlideElement.toggle();
 
       resolve();
     });
@@ -205,7 +205,7 @@ public static void main(String args[]) {
 </script>
 
 <div style="position: fixed; bottom: 0; right: 0; padding: 32px;">
-  <button onclick="playVideo()">Play video</button>
+  <button onclick="toggleVideo()">Toggle video</button>
   <button onclick="slidePrev()">Prev</button>
   <button onclick="slideNext()">Next</button>
   <button onclick="slideTo()">Slide to</button>


### PR DESCRIPTION
Adds `@Method() toggle` to the `<deckgo-slide-youtube>` component, which alternates between `play` and `pause` states. 

TODO: post a message from the YouTube iFrame when the video is played/paused, so that `<deckgo-slide-youtube>` keeps an internal `@State() isPlaying` in sync with the video. Currently this implementation only works if `play`, `pause`, or `toggle` are called programmatically.