### PR TITLE
Added deckgo-slide-countdown slide web core component

### DIFF
--- a/webcomponents/core/src/components.d.ts
+++ b/webcomponents/core/src/components.d.ts
@@ -98,6 +98,25 @@ export namespace Components {
     'reveal': boolean;
     'revealShowFirst': boolean;
   }
+  interface DeckgoSlideCountdown {
+    'afterSwipe': () => Promise<void>;
+    'beforeSwipe': (_enter: boolean) => Promise<boolean>;
+    /**
+    * Hours input for the timer.
+    */
+    'hours': number;
+    'lazyLoadContent': () => Promise<void>;
+    /**
+    * Minutes input for the timer.
+    */
+    'minutes': number;
+    /**
+    * Seconds input for the timer.
+    */
+    'seconds': number;
+    'start': () => Promise<void>;
+    'stop': () => Promise<void>;
+  }
   interface DeckgoSlideGif {
     'afterSwipe': () => Promise<void>;
     'alt': string;
@@ -213,6 +232,12 @@ declare global {
     new (): HTMLDeckgoSlideContentElement;
   };
 
+  interface HTMLDeckgoSlideCountdownElement extends Components.DeckgoSlideCountdown, HTMLStencilElement {}
+  var HTMLDeckgoSlideCountdownElement: {
+    prototype: HTMLDeckgoSlideCountdownElement;
+    new (): HTMLDeckgoSlideCountdownElement;
+  };
+
   interface HTMLDeckgoSlideGifElement extends Components.DeckgoSlideGif, HTMLStencilElement {}
   var HTMLDeckgoSlideGifElement: {
     prototype: HTMLDeckgoSlideGifElement;
@@ -262,6 +287,7 @@ declare global {
     'deckgo-slide-chart': HTMLDeckgoSlideChartElement;
     'deckgo-slide-code': HTMLDeckgoSlideCodeElement;
     'deckgo-slide-content': HTMLDeckgoSlideContentElement;
+    'deckgo-slide-countdown': HTMLDeckgoSlideCountdownElement;
     'deckgo-slide-gif': HTMLDeckgoSlideGifElement;
     'deckgo-slide-qrcode': HTMLDeckgoSlideQrcodeElement;
     'deckgo-slide-split': HTMLDeckgoSlideSplitElement;
@@ -345,6 +371,21 @@ declare namespace LocalJSX {
     'reveal'?: boolean;
     'revealShowFirst'?: boolean;
   }
+  interface DeckgoSlideCountdown extends JSXBase.HTMLAttributes<HTMLDeckgoSlideCountdownElement> {
+    /**
+    * Hours input for the timer.
+    */
+    'hours'?: number;
+    /**
+    * Minutes input for the timer.
+    */
+    'minutes'?: number;
+    'onSlideDidLoad'?: (event: CustomEvent<void>) => void;
+    /**
+    * Seconds input for the timer.
+    */
+    'seconds'?: number;
+  }
   interface DeckgoSlideGif extends JSXBase.HTMLAttributes<HTMLDeckgoSlideGifElement> {
     'alt'?: string;
     'customActions'?: boolean;
@@ -404,6 +445,7 @@ declare namespace LocalJSX {
     'deckgo-slide-chart': DeckgoSlideChart;
     'deckgo-slide-code': DeckgoSlideCode;
     'deckgo-slide-content': DeckgoSlideContent;
+    'deckgo-slide-countdown': DeckgoSlideCountdown;
     'deckgo-slide-gif': DeckgoSlideGif;
     'deckgo-slide-qrcode': DeckgoSlideQrcode;
     'deckgo-slide-split': DeckgoSlideSplit;

--- a/webcomponents/core/src/components/slides/deckgo-slide-countdown/deckdeckgo-slide-countdown.scss
+++ b/webcomponents/core/src/components/slides/deckgo-slide-countdown/deckdeckgo-slide-countdown.scss
@@ -1,0 +1,133 @@
+@import "../deckdeckgo-slide";
+
+// Custom properties
+// --countdown-base-size : Initial component base size. 
+// --clock-background-color : Clock's background color
+// --clock-foreground-color : Clock's digits' color
+
+:host {
+  font-size: var(--countdown-base-size, 16px);
+}
+
+// Title and content
+::slotted([slot=title]),
+::slotted([slot=content]) {
+  text-align: center;
+}
+
+div.deckgo-slide {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+// Countdown
+.countdown {
+  display: flex;
+
+  .time-container {
+    margin-right: 2.82em;
+    text-align: center;
+
+    .count-title {
+      display: block;
+      margin-bottom: .94em;
+      margin-top: .94em;
+      font-style: normal;
+      font-variant-ligatures: normal;
+      font-variant-caps: normal;
+      font-variant-numeric: normal;
+      font-variant-east-asian: normal;
+      font-weight: normal;
+      font-stretch: normal;
+      font-size: 0.94em;
+      line-height: normal;
+      color: #1a1a1a;
+      text-transform: uppercase;
+    }
+
+    .figure-container {
+      display: flex;
+
+      .figure {
+        position: relative;
+        float: left;
+        height: 6.87em;
+        width: 6.25em;
+        margin-right: .625em;
+        background-color: var(--clock-background-color, #fff);
+        border-radius: 0.5em;
+        box-shadow: 0 3px 4px 0 rgba(0, 0, 0, .2), inset 2px 4px 0 0 rgba(255, 255, 255, .08);
+
+        &:last-child {
+          margin-right: 0;
+        }
+
+        > span {
+          position: absolute;
+          left: 0;
+          right: 0;
+          margin: auto;
+          font-style: normal;
+          font-variant-ligatures: normal;
+          font-variant-caps: normal;
+          font-variant-numeric: normal;
+          font-variant-east-asian: normal;
+          font-weight: 700;
+          font-stretch: normal;
+          font-size: 5.94em;
+          line-height: 1.15em;
+          font-weight: 700;
+          color: var(--clock-foreground-color, #de4848);
+        }
+
+        .top {
+          z-index: 3;
+          background-color: var(--clock-background-color, #fff);
+          transform-origin: 50% 100%;
+          -webkit-transform-origin: 50% 100%;
+          border-top-left-radius: .625em;
+          border-top-right-radius: .625em;
+          transform: 12.5em;
+          perspective: 12.5em;
+          height: 50%;
+          overflow: hidden;
+          backface-visibility: hidden;
+
+          &:after {
+            content: "";
+            position: absolute;
+            z-index: -1;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+            border-bottom: 1px solid rgba(0, 0, 0, .1);
+          }
+        }
+
+        .bottom {
+          z-index: 1;
+
+          &:before {
+            content: "";
+            position: absolute;
+            display: block;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 50%;
+            background-color: rgba(0, 0, 0, .02);
+          }
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 786px) {
+  .countdown {
+    flex-direction: column;
+  }
+}

--- a/webcomponents/core/src/components/slides/deckgo-slide-countdown/deckgo-slide-countdown.tsx
+++ b/webcomponents/core/src/components/slides/deckgo-slide-countdown/deckgo-slide-countdown.tsx
@@ -1,0 +1,382 @@
+import { Component, Method, Prop, h, Watch, Event, EventEmitter, Host } from '@stencil/core';
+
+import { DeckdeckgoSlide } from '../deckdeckgo-slide';
+
+@Component({
+  tag: 'deckgo-slide-countdown',
+  styleUrl: 'deckdeckgo-slide-countdown.scss',
+  shadow: true
+})
+export class DeckdeckgoSlideCountdown implements DeckdeckgoSlide {
+
+  @Event()
+  slideDidLoad: EventEmitter<void>;
+
+  /**
+   * Hours input for the timer.
+   */
+  @Prop()
+  public hours = 0;
+
+  /**
+   * Minutes input for the timer.
+   */
+  @Prop()
+  public minutes = 0;
+
+  /**
+   * Seconds input for the timer.
+   */
+  @Prop()
+  public seconds = 0;
+
+  @Method()
+  public async start(): Promise<void> {
+
+    this.stop();
+
+    this.init();
+    this.startCountdown();
+
+  }
+
+  @Method()
+  public async stop(): Promise<void> {
+
+    this.clearUp();
+
+  }
+
+  @Watch('hours')
+  hoursChangeHandler(newValue: number, _oldValue: number) {
+
+    this.hours = newValue;
+
+    this.clearUp();
+
+  }
+
+  @Watch('minutes')
+  minutesChangeHandler(newValue: number, _oldValue: number) {
+
+    this.minutes = newValue;
+
+    this.clearUp();
+
+  }
+
+  @Watch('seconds')
+  secondsChangeHandler(newValue: number, _oldValue: number) {
+
+    this.seconds = newValue;
+
+    this.clearUp();
+
+  }
+
+  private mHours = 0;
+  private mMinutes = 0;
+  private mSeconds = 0;
+
+  private mHoursElement: HTMLElement;
+  private mMinutesElement: HTMLElement;
+  private mSecondsElement: HTMLElement;
+
+  private mTotalSeconds = 0;
+  private mCountdownInterval = -1;
+
+  public componentDidLoad(): void {
+
+    this.slideDidLoad.emit();
+
+  }
+
+  public componentDidRender(): void {
+
+    this.init();
+    this.startCountdown();
+
+  }
+
+  public disconnectedCallback(): void {
+
+    this.clearUp();
+
+  }
+
+  public render(): any {
+
+    return <Host class={{ 'deckgo-slide-container': true }}>
+
+      <div class="deckgo-slide">
+        <slot name="title"></slot>
+        <div class="deckgo-countdown-container">
+          {this.renderCountdown()}
+        </div>
+      </div>
+
+    </Host>
+
+  }
+
+  @Method()
+  beforeSwipe(_enter: boolean): Promise<boolean> {
+
+    return Promise.resolve(true);
+
+  }
+
+  @Method()
+  afterSwipe(): Promise<void> {
+
+    this.clearUp();
+
+    return Promise.resolve();
+
+  }
+
+  @Method()
+  lazyLoadContent(): Promise<void> {
+
+    return Promise.resolve();
+
+  }
+
+  /**
+   * @internal
+   */
+  private init(): void {
+
+    this.mHours = this.hours;
+    this.mMinutes = this.minutes;
+    this.mSeconds = this.seconds;
+
+    this.mTotalSeconds = ((this.mHours * 60 * 60) + (this.mMinutes * 60) + this.mSeconds);
+
+    // Update time.
+    // Hours.
+    this.checkAndUpdateTime(this.mHours, TimeUnit.Hours);
+
+    // Minutes.
+    this.checkAndUpdateTime(this.mMinutes, TimeUnit.Minutes);
+
+    // Seconds.
+    this.checkAndUpdateTime(this.mSeconds, TimeUnit.Seconds);
+
+  }
+
+  /**
+   * @internal
+   */
+  private clearUp() {
+
+    if (this.mCountdownInterval > -1) {
+
+      clearInterval(this.mCountdownInterval);
+
+      this.mCountdownInterval = -1;
+
+    }
+
+  }
+
+  /**
+   * @internal
+   */
+  private startCountdown(): void {
+
+    this.mCountdownInterval = setInterval(() => {
+
+      if (this.mTotalSeconds > 0) {
+
+        --this.mSeconds;
+
+        if (this.mMinutes >= 0 && this.mSeconds < 0) {
+
+          this.mSeconds = 59;
+          --this.mMinutes;
+
+        }
+
+        if (this.mHours >= 0 && this.mMinutes < 0) {
+
+          this.mMinutes = 59;
+          --this.mHours;
+
+        }
+
+        // Update time.
+        // Hours.
+        this.checkAndUpdateTime(this.mHours, TimeUnit.Hours);
+
+        // Minutes.
+        this.checkAndUpdateTime(this.mMinutes, TimeUnit.Minutes);
+
+        // Seconds.
+        this.checkAndUpdateTime(this.mSeconds, TimeUnit.Seconds);
+
+        --this.mTotalSeconds;
+
+      } else {
+
+        clearInterval(this.mCountdownInterval);
+        this.mCountdownInterval = -1;
+
+      }
+
+    }, 1000);
+
+  }
+
+  /**
+   * @internal
+   */
+  private checkAndUpdateTime(value: number, type: TimeUnit): void {
+
+    const valueStr = value.toString();
+
+    if (value >= 10) {
+
+      this.animateTimeSlot(valueStr.charAt(0), valueStr.charAt(1), type);
+
+    } else if (value >= 0) {
+
+      this.animateTimeSlot('0', valueStr.charAt(0), type);
+
+    }
+
+  }
+
+  /**
+   * @internal
+   */
+  private animateTimeSlot(tensValue: string, unitValue: string, type: TimeUnit): void {
+
+    switch (type) {
+
+      case TimeUnit.Hours:
+        this.animateFigure(this.mHoursElement, tensValue, unitValue);
+        break;
+
+      case TimeUnit.Minutes:
+        this.animateFigure(this.mMinutesElement, tensValue, unitValue);
+        break;
+
+      case TimeUnit.Seconds:
+        this.animateFigure(this.mSecondsElement, tensValue, unitValue);
+        break;
+
+    }
+
+  }
+
+  /**
+   * @internal
+   */
+  private animateFigure(timeSlotElem: HTMLElement, tensValue: string, unitValue: string): void {
+
+    const figureTensElem = timeSlotElem.querySelector('.figure.tens');
+    const figureUnitElem = timeSlotElem.querySelector('.figure.unit');
+
+    this.animateTopAndBottom(figureTensElem, tensValue);
+    this.animateTopAndBottom(figureUnitElem, unitValue);
+
+  }
+
+  /**
+   * @internal
+   */
+  private animateTopAndBottom(figureElem: Element, value: string): void {
+
+    const topElem = figureElem.querySelector('.top');
+    const bottomElem = figureElem.querySelector('.bottom');
+
+    if (topElem.innerHTML === value) {
+      return;
+    }
+
+    topElem.innerHTML = value;
+    bottomElem.innerHTML = value;
+
+  }
+
+  private renderCountdown(): any {
+
+    return <div class="countdown">
+
+      <div class="time-container hours" ref={(elem) => this.mHoursElement = elem}>
+
+        <span class="count-title">Hours</span>
+
+        <div class="figure-container">
+
+          <div class="figure hours tens">
+            <span class="top">0</span>
+            <span class="bottom">0</span>
+          </div>
+
+          <div class="figure hours unit">
+            <span class="top">0</span>
+            <span class="bottom">0</span>
+          </div>
+
+        </div>
+
+      </div>
+
+      <div class="time-container min" ref={(elem) => this.mMinutesElement = elem}>
+
+        <span class="count-title">Minutes</span>
+
+        <div class="figure-container">
+
+          <div class="figure min tens">
+            <span class="top">0</span>
+            <span class="bottom">0</span>
+          </div>
+
+          <div class="figure min unit">
+            <span class="top">0</span>
+            <span class="bottom">0</span>
+          </div>
+
+        </div>
+
+      </div>
+
+      <div class="time-container sec" ref={(elem) => this.mSecondsElement = elem}>
+
+        <span class="count-title">Seconds</span>
+
+        <div class="figure-container">
+
+          <div class="figure sec tens">
+            <span class="top">0</span>
+            <span class="bottom">0</span>
+          </div>
+
+          <div class="figure sec unit">
+            <span class="top">0</span>
+            <span class="bottom">0</span>
+          </div>
+
+        </div>
+
+      </div>
+
+    </div>
+
+  }
+
+}
+
+/**
+ * @internal
+ */
+enum TimeUnit {
+
+  Hours = 'Hours',
+  Minutes = 'Minutes',
+  Seconds = 'Seconds'
+
+}

--- a/webcomponents/core/src/index.html
+++ b/webcomponents/core/src/index.html
@@ -15,6 +15,11 @@
 <body style="margin: 0; overflow: hidden;">
 
 <deckgo-deck id="slider">
+
+  <deckgo-slide-countdown hours="0" minutes="0" seconds="5">
+    <h1 slot="title">My presentation will start in</h1>
+  </deckgo-slide-countdown>
+
   <deckgo-slide-title>
     <h1 slot="title">DeckDeckGo</h1>
     <p slot="content">


### PR DESCRIPTION
This commit adds ```deckgo-slide-countdown``` web core slide component.

Please see https://github.com/deckgo/deckdeckgo/issues/45

Usages:
```
<deckgo-slide-countdown hours="0" minutes="0" seconds="5">
  <h1 slot="title">My presentation will start in</h1>
</deckgo-slide-countdown>
```

Exposed public method on the HTML element:
```
start() - To start the countdown.
stop() - To stop the countdown.
```

Exposed CSS custom properties:
```
--countdown-base-size : Initial component base size. 
--clock-background-color : Clock's background color
--clock-foreground-color : Clock's digits' color.
```