### PR TITLE
feat(#263): when switching to fullscreen mode, presenting mode per default not the edition mode

### DIFF
--- a/studio/src/app/pages/editor/app-editor/app-editor.tsx
+++ b/studio/src/app/pages/editor/app-editor/app-editor.tsx
@@ -430,6 +430,9 @@ export class AppEditor {
                 return;
             }
 
+            // Per default, when we switch to the fullscreen mode, we want to present the presentation not edit it
+            this.presenting = !this.fullscreen;
+
             await this.editorEventsHandler.selectDeck();
             await (deck as any).toggleFullScreen();
 


### PR DESCRIPTION
Solves #263