### PR TITLE
Set color-container class overflow to visible - resolves #390

### DIFF
--- a/webcomponents/color/src/components/color/deckdeckgo-color.scss
+++ b/webcomponents/color/src/components/color/deckdeckgo-color.scss
@@ -9,7 +9,7 @@ div.color-container {
   align-items: center;
   flex-wrap: var(--deckgo-flex-wrap, wrap);
 
-  overflow: auto;
+  overflow: visible;
 
   button, div.more {
     width: var(--deckgo-button-width, 28px);


### PR DESCRIPTION
## Description
This PR resolves #390. The overflow property of the container of the color picker Web Component has been set as visible

## Screenshot
![image](https://user-images.githubusercontent.com/5564120/66197232-2ded0f80-e6c4-11e9-9f7b-3020c0e40a7a.png)
