### PR TITLE
Update keyboard assist to support Vim keybindings

### DIFF
--- a/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
+++ b/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
@@ -187,9 +187,9 @@ export class DeckdeckgoDeck {
       return;
     }
 
-    if ($event.key === 'ArrowLeft') {
+    if (['ArrowLeft', 'k'].indexOf($event.key) !== -1) {
       await this.slideNextPrev(false, true);
-    } else if ($event.key === 'ArrowRight') {
+    } else if (['ArrowRight', 'j'].indexOf($event.key) !== -1) {
       await this.slideNextPrev(true, true);
     }
   };


### PR DESCRIPTION
Resolves issue #388
- Pressing J will go to the next slide
- Pressing K will go to the previous slide

Made it easy to insert other keys when required such as P and N for Emac/other users

Not sure if there's any tests that need to be created, quite new to contributing. Please let me know otherwise.