### PR TITLE
Studio: display tags and hide title on cards in the main feed

### DIFF
--- a/studio/src/app/components/feed/card/app-feed-card/app-feed-card.scss
+++ b/studio/src/app/components/feed/card/app-feed-card/app-feed-card.scss
@@ -16,6 +16,7 @@ app-feed-card {
       }
 
       ion-card-title {
+        display: none;
         white-space: nowrap;
         overflow: hidden;
         font-size: var(--font-size-h1);

--- a/studio/src/app/components/feed/card/app-feed-card/app-feed-card.scss
+++ b/studio/src/app/components/feed/card/app-feed-card/app-feed-card.scss
@@ -6,7 +6,7 @@ app-feed-card {
     ion-card-content {
 
       &.compact {
-        app-feed-card-tags, p.content {
+        p.content {
           display: none;
         }
       }


### PR DESCRIPTION
### Description
Hid the title from all the cards present in the main feed. Slide tags are now displayed for all slides on the main feed.

### Verification
Verified that the changes work as expected on the local build.

### Applicable Issue
Closes #371 