### PR TITLE
fix: slide qrcode default width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Web Components
 * charts: v1.0.0-rc.2 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/webcomponents/charts/CHANGELOG.md))
 * slide-chart: v1.0.0-rc.1-1 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/webcomponents/slides/chart/CHANGELOG.md))
+* slide-qrcode: v1.0.0-rc.2-1 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/webcomponents/slides/qrcode/CHANGELOG.md))
 
 <a name="1.0.0-rc.15"></a>
 # [1.0.0-rc.15](https://github.com/deckgo/deckdeckgo/compare/v1.0.0-rc.14-2...v1.0.0-15) (2019-10-07)

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -87,9 +87,9 @@
       }
     },
     "@deckdeckgo/slide-qrcode": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@deckdeckgo/slide-qrcode/-/slide-qrcode-1.0.0-rc.2.tgz",
-      "integrity": "sha512-SSaHZzDAuJbCTwJAXTxCAP4ID9zUon5/l9Z+AhsoSN+8iKzlCom/x1JVMAFSF5aVqv//jixGYI6DAB6Y0ht6dQ==",
+      "version": "1.0.0-rc.2-1",
+      "resolved": "https://registry.npmjs.org/@deckdeckgo/slide-qrcode/-/slide-qrcode-1.0.0-rc.2-1.tgz",
+      "integrity": "sha512-3dZBhZkl01ShW0FBcGaymXBXakkUGq9QpKWauvYCTLGE0KKGHeIxQrfUa2AZZANIuzZiHrCktR9oLW8Dk4Akaw==",
       "requires": {
         "@deckdeckgo/slide-utils": "^1.0.0-rc.3",
         "@deckdeckgo/utils": "^1.0.0-rc.1"

--- a/studio/package.json
+++ b/studio/package.json
@@ -24,7 +24,7 @@
     "@deckdeckgo/slide-author": "^1.0.0-rc.1",
     "@deckdeckgo/slide-content": "^1.0.0-rc.1",
     "@deckdeckgo/slide-gif": "^1.0.0-rc.1-1",
-    "@deckdeckgo/slide-qrcode": "^1.0.0-rc.2",
+    "@deckdeckgo/slide-qrcode": "^1.0.0-rc.2-1",
     "@deckdeckgo/slide-split": "^1.0.0-rc.1",
     "@deckdeckgo/slide-title": "^1.0.0-rc.1",
     "@deckdeckgo/slide-youtube": "^1.0.0-rc.1-3",

--- a/webcomponents/slides/qrcode/CHANGELOG.md
+++ b/webcomponents/slides/qrcode/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="1.0.0-rc.2-1"></a>
+# 1.0.0-rc.2-1 (2019-10-12)
+
+### Fix
+
+* don't set a default 100% value as it might be to wide depending on the slide format
+
 <a name="1.0.0-rc.2"></a>
 # 1.0.0-rc.2 (2019-10-07)
 

--- a/webcomponents/slides/qrcode/package-lock.json
+++ b/webcomponents/slides/qrcode/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deckdeckgo/slide-qrcode",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.2-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webcomponents/slides/qrcode/package.json
+++ b/webcomponents/slides/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deckdeckgo/slide-qrcode",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.2-1",
   "description": "The QR Code template is handy to display a QR Code in presentations which could, for example, point to your deck available as a PWA",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/webcomponents/slides/qrcode/src/components/slide/deckdeckgo-slide-qrcode.tsx
+++ b/webcomponents/slides/qrcode/src/components/slide/deckdeckgo-slide-qrcode.tsx
@@ -64,12 +64,8 @@ export class DeckdeckgoSlideQrcode implements DeckdeckgoSlideResize {
 
         const qrCode: HTMLElement = container.querySelector('deckgo-qrcode');
 
-        if (qrCode) {
-          if (width <= 0 && height <= 0) {
-            qrCode.style.setProperty('--deckgo-qrcode-size', '100%');
-          } else {
-            qrCode.style.setProperty('--deckgo-qrcode-size', width > height ? (height + 'px') : ('calc('  + width + 'px - 32px)'));
-          }
+        if (qrCode && width > 0 && height > 0) {
+          qrCode.style.setProperty('--deckgo-qrcode-size', width > height ? (height + 'px') : ('calc('  + width + 'px - 32px)'));
         }
       }
 


### PR DESCRIPTION
In the editor (studio), on Android devices, when use open the popover to select new slides, the QR code is displayed to big as it was set to a 100% width. Inheriting solve the issue.