### PR TITLE
Add basic vertical split functionality

### DIFF
--- a/webcomponents/slides/split/src/components.d.ts
+++ b/webcomponents/slides/split/src/components.d.ts
@@ -17,6 +17,7 @@ export namespace Components {
     'hideContent': () => Promise<void>;
     'lazyLoadContent': () => Promise<void>;
     'revealContent': () => Promise<void>;
+    'vertical': boolean;
   }
 }
 
@@ -38,6 +39,7 @@ declare namespace LocalJSX {
     'customActions'?: boolean;
     'customBackground'?: boolean;
     'onSlideDidLoad'?: (event: CustomEvent<void>) => void;
+    'vertical'?: boolean;
   }
 
   interface IntrinsicElements {

--- a/webcomponents/slides/split/src/components/slide/deckdeckgo-slide-split.scss
+++ b/webcomponents/slides/split/src/components/slide/deckdeckgo-slide-split.scss
@@ -8,6 +8,12 @@ div.deckgo-slide {
   height: var(--slide-height);
 }
 
+div.deckgo-slide-vertical {
+  @extend div, .deckgo-slide;
+  flex-flow: column wrap;
+  height: calc(var(--slide-height) - (2 * var(--slide-split-padding-bottom, var(--slide-padding-bottom-default))));
+}
+
 div.deckgo-slide-split {
   flex: 1;
 
@@ -29,6 +35,11 @@ div.deckgo-slide-split {
     background: var(--slide-split-background-end);
     color: var(--slide-split-color-end);
   }
+}
+
+div.deckgo-slide-split-vertical {
+  @extend div, .deckgo-slide-split;
+  width: calc(var(--slide-width) - (var(--slide-split-padding-end, var(--slide-padding-end-default))) - (var(--slide-split-padding-start, var(--slide-padding-start-default))));
 }
 
 ::slotted([slot="title"]) {

--- a/webcomponents/slides/split/src/components/slide/deckdeckgo-slide-split.scss
+++ b/webcomponents/slides/split/src/components/slide/deckdeckgo-slide-split.scss
@@ -11,7 +11,6 @@ div.deckgo-slide {
 div.deckgo-slide-vertical {
   @extend div, .deckgo-slide;
   flex-flow: column wrap;
-  height: calc(var(--slide-height) - (2 * var(--slide-split-padding-bottom, var(--slide-padding-bottom-default))));
 }
 
 div.deckgo-slide-split {
@@ -39,6 +38,7 @@ div.deckgo-slide-split {
 
 div.deckgo-slide-split-vertical {
   @extend div, .deckgo-slide-split;
+  height: calc((var(--slide-height) / 2) - (var(--slide-split-padding-bottom, var(--slide-padding-bottom-default))) - (var(--slide-split-padding-top, var(--slide-padding-top-default))));
   width: calc(var(--slide-width) - (var(--slide-split-padding-end, var(--slide-padding-end-default))) - (var(--slide-split-padding-start, var(--slide-padding-start-default))));
 }
 

--- a/webcomponents/slides/split/src/components/slide/deckdeckgo-slide-split.tsx
+++ b/webcomponents/slides/split/src/components/slide/deckdeckgo-slide-split.tsx
@@ -15,6 +15,7 @@ export class DeckdeckgoSlideSplit implements DeckdeckgoSlide {
 
   @Prop({reflectToAttr: true}) customActions: boolean = false;
   @Prop({reflectToAttr: true}) customBackground: boolean = false;
+  @Prop() vertical: boolean = false;
 
   async componentDidLoad() {
     await hideLazyLoadImages(this.el);
@@ -48,11 +49,12 @@ export class DeckdeckgoSlideSplit implements DeckdeckgoSlide {
   }
 
   render() {
+    const verticalAttr = this.vertical ? '-vertical' : '';
     return <Host class={{'deckgo-slide-container': true}}>
-      <div class="deckgo-slide">
+      <div class={`deckgo-slide${verticalAttr}`}>
         <slot name="title"></slot>
-        <div class="deckgo-slide-split deckgo-slide-split-start"><slot name="start"></slot></div>
-        <div class="deckgo-slide-split deckgo-slide-split-end"><slot name="end"></slot></div>
+        <div class={`deckgo-slide-split${verticalAttr} deckgo-slide-split-start`}><slot name="start"></slot></div>
+        <div class={`deckgo-slide-split${verticalAttr} deckgo-slide-split-end`}><slot name="end"></slot></div>
         <slot name="notes"></slot>
         <slot name="actions"></slot>
         <slot name="background"></slot>

--- a/webcomponents/slides/split/src/index.html
+++ b/webcomponents/slides/split/src/index.html
@@ -23,6 +23,16 @@
       Hello World 1 <a href="https://ionicframework.com">Ionic</a> 🚀
     </div>
     <div slot="end">
+      Hello World 2 <a href="https://ionicframework.com">Ionic</a> 🚀
+    </div>
+  </deckgo-slide-split>
+
+  <deckgo-slide-split vertical>
+    <h1 slot="title">DeckDeckGo</h1>
+    <div slot="start">
+      Hello World 1 <a href="https://ionicframework.com">Ionic</a> 🚀
+    </div>
+    <div slot="end">
       Cool beans
       <img data-src="https://deckdeckgo.com/assets/img/deckdeckgo.png" alt="DeckDeckGo" style="width: 50px"/>
     </div>


### PR DESCRIPTION
Summary:

- Add Prop() `vertical` to DeckdeckgoSlideSplit
- Append attribute `-vertical` to slide classes `deckgo-slide` and `deckgo-slide-split`
- Add and extend `deckgo-slide-vertical` and `deckgo-slide-split-vertical` styles:
  - `deckgo-slide-vertical`
    - flex-flow is `column wrap`
    - height is slide height - bottom paddings * 2: `calc(var(--slide-height) - (2 * var(--slide-split-padding-bottom, var(--slide-padding-bottom-default))))`
  - `deckgo-slide-split-vertical`
    - width is slide width - end & start paddings: `calc(var(--slide-width) - (var(--slide-split-padding-end, var(--slide-padding-end-default))) - (var(--slide-split-padding-start, var(--slide-padding-start-default))));`

Closes #372 🚀