### PR TITLE
fix(#423): fix wrong code highlight when line numbers are off

### DIFF
--- a/webcomponents/highlight-code/src/components/highlight-code/deckdeckgo-highlight-code.tsx
+++ b/webcomponents/highlight-code/src/components/highlight-code/deckdeckgo-highlight-code.tsx
@@ -183,35 +183,30 @@ export class DeckdeckgoHighlightCode {
 
       if (container) {
         try {
-          if (this.lineNumbers) {
-            // clear the container first
-            container.children[0].innerHTML = '';
+          // clear the container first
+          container.children[0].innerHTML = '';
 
-            // split the code on linebreaks
-            const regEx = RegExp(/\n(?!$)/g); //
-            const match = code.split(regEx);
-            match.forEach((m, idx, array) => {
-              // On last element
-              if (idx === array.length - 1){
-                this.attachHighlightObserver(container);
-              }
+          // split the code on linebreaks
+          const regEx = RegExp(/\n(?!$)/g); //
+          const match = code.split(regEx);
+          match.forEach((m, idx, array) => {
+            // On last element
+            if (idx === array.length - 1) {
+              this.attachHighlightObserver(container);
+            }
 
-              let div: HTMLElement = document.createElement('div');
+            let div: HTMLElement = document.createElement('div');
+            if (this.lineNumbers) {
               div.classList.add('deckgo-highlight-code-line-number');
+            }
 
-              const highlight: string = Prism.highlight(m, Prism.languages[this.language], this.language);
+            const highlight: string = Prism.highlight(m, Prism.languages[this.language], this.language);
 
-              // If empty, use \u200B as zero width text spacer
-              div.innerHTML = highlight && highlight !== '' ? highlight : '\u200B';
+            // If empty, use \u200B as zero width text spacer
+            div.innerHTML = highlight && highlight !== '' ? highlight : '\u200B';
 
-              container.children[0].appendChild(div);
-            });
-          }else{
-            this.attachHighlightObserver(container);
-
-            container.children[0].innerHTML = Prism.highlight(code, Prism.languages[this.language], this.language);
-          }
-
+            container.children[0].appendChild(div);
+          });
           await this.addAnchors();
 
           resolve();
@@ -233,7 +228,7 @@ export class DeckdeckgoHighlightCode {
 
       observer.observe(container);
     } else {
-       // Back in my days...
+      // Back in my days...
       setTimeout(async () => {
         await this.addHighlight();
       }, 100);

--- a/webcomponents/highlight-code/src/index.html
+++ b/webcomponents/highlight-code/src/index.html
@@ -129,5 +129,28 @@
     System.out.println(isNegative.computeTest(-5));
     }</code>
 </deckgo-highlight-code>
+
+<h1>Issue #423</h1>
+<deckgo-highlight-code language="java" highlight-lines="6,7">
+  <code slot="code"># main.tf
+
+    resource "aws_lambda_function" "api" {
+    function_name = "deckdeckgo-handler-lambda"
+
+    filename      =
+    data.external.build-function.result.path
+
+    runtime = ...
+    }
+
+    data "external" "build-function" {
+    program = [
+    "nix",
+    "eval",
+    "(import ./default.nix).function-handler-path",
+    "--json",
+    ]
+    }</code>
+</deckgo-highlight-code>
 </body>
 </html>


### PR DESCRIPTION

Fixes #423 Wrap code in a div when line nubmers are turned off to ensure correct highlighting

![image](https://user-images.githubusercontent.com/1394063/67194780-0f8f4f80-f3f8-11e9-8709-191a8efcf165.png)
