### PR TITLE
Feat: PageUp/PageDown

### DIFF
--- a/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
+++ b/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
@@ -56,7 +56,7 @@ export class DeckdeckgoDeck {
 
   private fullscreen: boolean = false;
   private cursorHidden: boolean = false;
-  private idleMouseTimer: NodeJS.Timeout;
+  private idleMouseTimer: number;
 
   @Event() mouseInactivity: EventEmitter<boolean>;
 
@@ -756,7 +756,7 @@ export class DeckdeckgoDeck {
       return;
     }
 
-    if (this.idleMouseTimer) {
+    if (this.idleMouseTimer > 0) {
       clearTimeout(this.idleMouseTimer);
     }
 

--- a/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
+++ b/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
@@ -187,9 +187,9 @@ export class DeckdeckgoDeck {
       return;
     }
 
-    if (['ArrowLeft', 'k'].indexOf($event.key) !== -1) {
+    if (['ArrowLeft', 'k', 'PageUp'].indexOf($event.key) !== -1) {
       await this.slideNextPrev(false, true);
-    } else if (['ArrowRight', 'j'].indexOf($event.key) !== -1) {
+    } else if (['ArrowRight', 'j', 'PageDown'].indexOf($event.key) !== -1) {
       await this.slideNextPrev(true, true);
     }
   };

--- a/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
+++ b/webcomponents/core/src/components/deck/deckdeckgo-deck/deckdeckgo-deck.tsx
@@ -56,7 +56,7 @@ export class DeckdeckgoDeck {
 
   private fullscreen: boolean = false;
   private cursorHidden: boolean = false;
-  private idleMouseTimer: number;
+  private idleMouseTimer: NodeJS.Timeout;
 
   @Event() mouseInactivity: EventEmitter<boolean>;
 
@@ -756,7 +756,7 @@ export class DeckdeckgoDeck {
       return;
     }
 
-    if (this.idleMouseTimer > 0) {
+    if (this.idleMouseTimer) {
       clearTimeout(this.idleMouseTimer);
     }
 


### PR DESCRIPTION
For now, deckdeckgo-deck only supports arrow keys and k/j for moving to previous/next slide.

As some remote controlers (actually, mine) send PageUp/PageDown, adding this two keys permit to use those.

I also fixed a typing issue BTW as it was breaking the build.

FYI: I need it because during a long session with demos (3 hours long in my case), or when you are stuck behind a desk/screen for other reasons (e.g. camera), using a smartphone as a remote controller is way less convenient than a small remote controller.