### PR TITLE
feat: fetch more cards on the main feed (each steps)

### DIFF
--- a/studio/src/app/services/data/feed/feed.service.tsx
+++ b/studio/src/app/services/data/feed/feed.service.tsx
@@ -19,7 +19,7 @@ export class FeedService {
 
     private nextQueryAfter: firebase.firestore.DocumentSnapshot;
 
-    private queryLimit: number = 10;
+    private queryLimit: number = 20;
 
     private decks: Deck[] = [];
 


### PR DESCRIPTION
Let's see but I think both in terms of performances as in terms of costs we are able to fetch more cards on each steps (of the infinite scroll) on the main feed.

Instead of 10 cards (aka 10 presentations) at a time, let's try to fetch 20.

As the cards are randomized in the feed, this is a bit more user friendly for both user browsing (almost same performance but more information) as for publisher because there is then more chances that their presentations would appears at the top of the list more often.

P.S.: We could always rollback easily to 10 again if needed.