### PR TITLE
lazy-img: fix lazy img svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * core: v1.0.0-rc.3-4 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/webcomponents/core/CHANGELOG.md))
 * highlight-code: v1.0.0-rc.2-1 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/webcomponents/highlight-code/CHANGELOG.md))
 * inline-editor: v1.0.0-rc.3-3 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/webcomponents/inline-editor/CHANGELOG.md))
+* lazy-img: v1.0.0-rc.2-2 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/webcomponents/lazy-img/CHANGELOG.md))
 
 ### Others
 * starter kit: v1.0.0-rc.6-3 ([CHANGELOG](https://github.com/deckgo/deckdeckgo-starter/blob/master/CHANGELOG.md))

--- a/webcomponents/lazy-img/CHANGELOG.md
+++ b/webcomponents/lazy-img/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="1.0.0-rc.2-2"></a>
+# 1.0.0-rc.2-2 (2019-12-13)
+
+### Fix
+
+* svg weren't displayed anymore since v1.0.0-rc.2
+
 <a name="1.0.0-rc.2-1"></a>
 # 1.0.0-rc.2-1 (2019-11-29)
 

--- a/webcomponents/lazy-img/package-lock.json
+++ b/webcomponents/lazy-img/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deckdeckgo/lazy-img",
-  "version": "1.0.0-rc.2-1",
+  "version": "1.0.0-rc.2-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webcomponents/lazy-img/package.json
+++ b/webcomponents/lazy-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deckdeckgo/lazy-img",
-  "version": "1.0.0-rc.2-1",
+  "version": "1.0.0-rc.2-2",
   "description": "A dead simple Web Component to lazy load images",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/webcomponents/lazy-img/src/components/lazy-img/deckdeckgo-lazy-img.tsx
+++ b/webcomponents/lazy-img/src/components/lazy-img/deckdeckgo-lazy-img.tsx
@@ -195,7 +195,7 @@ export class DeckdeckgoLazyImg {
   }
 
   render() {
-    const hostClass: string = this.imgLoaded ? 'loaded' : '';
+    const hostClass: string = this.imgLoaded || this.svgContent ? 'loaded' : '';
 
     if (this.svgContent) {
       return <Host class={hostClass}>

--- a/webcomponents/lazy-img/src/index.html
+++ b/webcomponents/lazy-img/src/index.html
@@ -19,6 +19,8 @@
 </head>
 <body>
 
+  <deckgo-lazy-img svg-src="https://deckdeckgo.com/assets/icons/ionicons/twitter.svg"></deckgo-lazy-img>
+
   <deckgo-lazy-img img-width="300" img-height="200" img-src="https://docs.deckdeckgo.com/assets/img/deckdeckgoadsasd.png" img-error-src="https://deckdeckgo.com/assets/icons/album.svg"></deckgo-lazy-img>
 
   <deckgo-lazy-img intrinsicsize="300x300" img-src="https://docs.deckdeckgo.com/assets/img/deckdeckgasdadso.png"></deckgo-lazy-img>


### PR DESCRIPTION
Svg weren't displayed anymore as the detection of loaded was not correctly fully implemented.