### PR TITLE
refactor: remove beta from urls

### DIFF
--- a/studio/src/index.html
+++ b/studio/src/index.html
@@ -25,9 +25,9 @@
   <meta property="og:description" content="The open source web editor for presentations">
 
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://beta.deckdeckgo.com">
+  <meta property="og:url" content="https://deckdeckgo.com">
 
-  <meta property="og:image" content="https://beta.deckdeckgo.com/assets/favicon/android-chrome-512x512.png">
+  <meta property="og:image" content="https://deckdeckgo.com/assets/favicon/android-chrome-512x512.png">
   <meta property="og:image:type" content="image/png">
 
   <link rel="canonical" href="https://deckdeckgo.com"/>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `x`. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes

## Other information

I am not sure if this is done on purpose, but all of the other URLs are already linking to deckdeckgo.com without `beta.` in front. If done on purpose, this PR can be deleted.
