### PR TITLE
feat: remove editor popover backdrops

### DIFF
--- a/studio/src/app/components/editor/actions/deck/app-actions-deck/app-actions-deck.tsx
+++ b/studio/src/app/components/editor/actions/deck/app-actions-deck/app-actions-deck.tsx
@@ -84,6 +84,7 @@ export class AppActionsDeck {
       component: 'app-create-slide',
       event: $event.detail,
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu'
     });
 
@@ -348,6 +349,7 @@ export class AppActionsDeck {
         deckDidChange: this.deckDidChange
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu popover-menu-wide'
     });
 

--- a/studio/src/app/components/editor/actions/element/app-actions-element/app-actions-element.tsx
+++ b/studio/src/app/components/editor/actions/element/app-actions-element/app-actions-element.tsx
@@ -453,6 +453,7 @@ export class AppActionsElement {
         selectedElement: this.selectedElement
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu'
     });
 
@@ -483,6 +484,7 @@ export class AppActionsElement {
         slideDidChange: this.slideDidChange
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu'
     });
 
@@ -512,6 +514,7 @@ export class AppActionsElement {
         selectedElement: this.selectedElement
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu'
     });
 
@@ -533,6 +536,7 @@ export class AppActionsElement {
         imgDidChange: this.imgDidChange
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu'
     });
 
@@ -572,6 +576,7 @@ export class AppActionsElement {
         selectedElement: this.selectedElement
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu'
     });
 
@@ -596,6 +601,7 @@ export class AppActionsElement {
         codeDidChange: this.codeDidChange
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: 'popover-menu'
     });
 
@@ -822,6 +828,7 @@ export class AppActionsElement {
         selectedElement: this.selectedElement
       },
       mode: 'md',
+      showBackdrop: false,
       cssClass: `popover-menu ${this.slideNodeName === 'deckgo-slide-poll' ? 'popover-menu-wide' : ''}`
     });
 

--- a/studio/src/global/theme/popover.scss
+++ b/studio/src/global/theme/popover.scss
@@ -23,7 +23,7 @@ ion-popover.popover-menu {
 
     transform-origin: right top !important;
 
-    box-shadow: none;
+    box-shadow: -8px 0 16px rgba(0, 0, 0, 0.12);
     border-radius: 0;
   }
 }


### PR DESCRIPTION
Backdrops in the editor, when it goes to editing, were a bit unpractical specially when it comes to colors as the selected color were applied behind a backdrop/shadow.

Removing the backdrops and adding a small box-shadow instead makes things more clear I think.