### PR TITLE
fix(#610): content sizing fit in Firefox

### DIFF
--- a/webcomponents/drag-resize-rotate/src/components/deckdeckgo-drr.scss
+++ b/webcomponents/drag-resize-rotate/src/components/deckdeckgo-drr.scss
@@ -1,5 +1,8 @@
 :host {
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   contain: size;
 
   width: var(--width);


### PR DESCRIPTION
Fix content sizing of the drag, resize and rotate component in Firefox