### PR TITLE
feat: box-shadow for the deck

### DIFF
--- a/studio/src/app/pages/editor/app-editor/app-editor.scss
+++ b/studio/src/app/pages/editor/app-editor/app-editor.scss
@@ -36,6 +36,10 @@ app-editor {
     height: 100%;
 
     overflow: hidden;
+
+    &.ready {
+      box-shadow: rgba(0, 0, 0, 0.2) 0 3px 1px -2px, rgba(0, 0, 0, 0.14) 0 2px 2px 0, rgba(0, 0, 0, 0.12) 0 1px 5px 0;
+    }
   }
 
   deckgo-inline-editor {

--- a/studio/src/app/popovers/editor/app-create-slide/app-create-slide.scss
+++ b/studio/src/app/popovers/editor/app-create-slide/app-create-slide.scss
@@ -16,7 +16,8 @@ app-create-slide {
       min-height: 7rem;
       height: fit-content;
       overflow: hidden;
-      box-shadow: 4px 4px 4px -4px rgba(var(--ion-color-medium-rgb), 0.4);
+      box-shadow: rgba(var(--ion-color-medium-rgb), 0.2) 0 3px 1px -2px, rgba(var(--ion-color-medium-rgb), 0.14) 0 2px 2px 0,
+        rgba(var(--ion-color-medium-rgb), 0.12) 0 1px 5px 0;
     }
 
     div.expand-charts {
@@ -202,11 +203,6 @@ app-create-slide {
     p {
       font-size: var(--font-size-small);
       border: 1px solid #dedede;
-    }
-
-    p[slot="content"],
-    p[slot="author"] {
-      font-size: var(--font-size-very-small);
     }
 
     p[slot="content"] {

--- a/studio/src/app/popovers/editor/app-create-slide/app-create-slide.tsx
+++ b/studio/src/app/popovers/editor/app-create-slide/app-create-slide.tsx
@@ -278,11 +278,11 @@ export class AppCreateSlide {
             poll-server={EnvironmentConfigService.getInstance().get('deckdeckgo').pollServerUrl}
             count-answers={3}
             connectPollSocket={false}>
-            <p slot="question">Poll: engage your audience</p>
+            <p slot="question">Poll: Engage Your Audience</p>
             <p slot="answer-1">Yes</p>
             <p slot="answer-2">No</p>
             <p slot="answer-3">Don't know</p>
-            <p slot="awaiting-votes">Live votes with mobile devices</p>
+            <p slot="awaiting-votes">Live Votes With Mobile Devices</p>
           </deckgo-slide-poll>
         </div>
 
@@ -316,7 +316,7 @@ export class AppCreateSlide {
         <div class="item" custom-tappable onClick={() => this.addRestrictedSlide(SlideTemplate.AUTHOR)}>
           <deckgo-slide-author class="showcase" img-src={this.photoUrl} img-alt="Author">
             <p slot="title">Author</p>
-            <p slot="author">About yourself</p>
+            <p slot="author">About Yourself</p>
             <p slot="social-link">Twitter</p>
             <p slot="social-link">LinkedIn</p>
             <p slot="social-link">Dev</p>

--- a/studio/src/global/theme/editor/editor-fullscreen.scss
+++ b/studio/src/global/theme/editor/editor-fullscreen.scss
@@ -44,6 +44,10 @@
   main {
     max-width: 100%;
 
+    &.ready {
+      box-shadow: none;
+    }
+
     &.idle {
       deckgo-deck {
         h1,


### PR DESCRIPTION
- add a md box-shadow around the edited deck (if not fullscreen and ready)

- improve template picker style
