### PR TITLE
Fix #655: Calculate center for element correctly

### DIFF
--- a/webcomponents/drag-resize-rotate/src/components/deckdeckgo-drr.tsx
+++ b/webcomponents/drag-resize-rotate/src/components/deckdeckgo-drr.tsx
@@ -214,8 +214,9 @@ export class DeckdeckgoDragResizeRotate {
   }
 
   private initStartPositionsRotation() {
-    this.centerX = this.el.getBoundingClientRect().left + this.el.offsetWidth / 2;
-    this.centerY = this.el.getBoundingClientRect().top + this.el.offsetHeight / 2;
+    let rect = this.el.getBoundingClientRect();
+    this.centerX = rect.left + rect.width / 2;
+    this.centerY = rect.top + rect.height / 2;
   }
 
   private initStartPositionsResize() {


### PR DESCRIPTION
Calculate center for element in a way that remains correct for different rotation values, aspect ratios of element, etc.

## PR Checklist
Please check if your PR fulfills the following requirements:

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `x`. -->

- [x] Bugfix

## Other information

<!-- Please provide any useful other information. -->

Issue Number: N/A
