### PR TITLE
feat(#507): deploy cloud and remote to firebase only on releases

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -1,11 +1,8 @@
 name: CI - Cloud
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'cloud/**'
+  release:
+    types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/remote.yml
+++ b/.github/workflows/remote.yml
@@ -1,11 +1,8 @@
 name: CI - Remote
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'remote/**'
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
Deploy remote and cloud automatically with GitHub Actions only on releases (no more "push master")