### PR TITLE
fix: alignment fonts in split template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Others
 
-- deck-utils: v2.0.0 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/utils/deck/CHANGELOG.md))
+- deck-utils: v2.1.0 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/master/utils/deck/CHANGELOG.md))
 - starter kit: v2.1.0 ([CHANGELOG](https://github.com/deckgo/deckdeckgo-starter/blob/master/CHANGELOG.md))
 
 <a name="1.0.0"></a>

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -989,9 +989,9 @@
       }
     },
     "@deckdeckgo/deck-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@deckdeckgo/deck-utils/-/deck-utils-2.0.0.tgz",
-      "integrity": "sha512-P+4RI3/1Y7v9H1v/xNH11cfnDFVXGkOBiGOssIYNXRJKwlyvha4Zhk0O8hsmenr2CGQqR72yQ8vPDdPKlKx7Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@deckdeckgo/deck-utils/-/deck-utils-2.1.0.tgz",
+      "integrity": "sha512-W+tCzTZVJAW+CUy/pnth3Iy67z/zLE9bjdkCRrcT2jrEbr66gLIJhAOjoK4TnWXRGXCLg5h11zIr7TPd3iK2CA==",
       "requires": {
         "@deckdeckgo/utils": "^1.1.0"
       }

--- a/remote/package.json
+++ b/remote/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@deckdeckgo/charts": "^1.0.1",
     "@deckdeckgo/core": "^1.0.1",
-    "@deckdeckgo/deck-utils": "^2.0.0",
+    "@deckdeckgo/deck-utils": "^2.1.0",
     "@deckdeckgo/drag-resize-rotate": "^1.0.0",
     "@deckdeckgo/highlight-code": "^1.0.2",
     "@deckdeckgo/lazy-img": "^1.0.0",

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -82,9 +82,9 @@
       }
     },
     "@deckdeckgo/deck-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@deckdeckgo/deck-utils/-/deck-utils-2.0.0.tgz",
-      "integrity": "sha512-P+4RI3/1Y7v9H1v/xNH11cfnDFVXGkOBiGOssIYNXRJKwlyvha4Zhk0O8hsmenr2CGQqR72yQ8vPDdPKlKx7Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@deckdeckgo/deck-utils/-/deck-utils-2.1.0.tgz",
+      "integrity": "sha512-W+tCzTZVJAW+CUy/pnth3Iy67z/zLE9bjdkCRrcT2jrEbr66gLIJhAOjoK4TnWXRGXCLg5h11zIr7TPd3iK2CA==",
       "requires": {
         "@deckdeckgo/utils": "^1.1.0"
       }

--- a/studio/package.json
+++ b/studio/package.json
@@ -19,7 +19,7 @@
     "@deckdeckgo/charts": "^1.0.1",
     "@deckdeckgo/color": "^1.1.0",
     "@deckdeckgo/core": "^1.0.1",
-    "@deckdeckgo/deck-utils": "^2.0.0",
+    "@deckdeckgo/deck-utils": "^2.1.0",
     "@deckdeckgo/drag-resize-rotate": "^1.0.0",
     "@deckdeckgo/highlight-code": "^1.0.2",
     "@deckdeckgo/inline-editor": "^1.2.0",

--- a/utils/deck/CHANGELOG.md
+++ b/utils/deck/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fix
 
 - `deckgo-slide-split` alignment in case of children (`b`, `i`, etc.)
+- `line-height` was too big in cas a small font size would be used
 
 <a name="2.0.0"></a>
 

--- a/utils/deck/CHANGELOG.md
+++ b/utils/deck/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="2.1.0"></a>
+
+# 2.1.0 (2020-05-03)
+
+### Fix
+
+- `deckgo-slide-split` alignment in case of children (`b`, `i`, etc.)
+
 <a name="2.0.0"></a>
 
 # 2.0.0 (2020-05-01)

--- a/utils/deck/package-lock.json
+++ b/utils/deck/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deckdeckgo/deck-utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/utils/deck/package.json
+++ b/utils/deck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deckdeckgo/deck-utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "David Dal Busco",
   "description": "Utils and styles for the DeckDeckGo applications",
   "license": "MIT",

--- a/utils/deck/styles/deck/deck.scss
+++ b/utils/deck/styles/deck/deck.scss
@@ -45,15 +45,10 @@ deckgo-deck deckgo-lazy-img[slot] {
 deckgo-slide-split {
   --slide-split-align: center;
   --slide-split-text-align: center;
-}
-
-deckgo-slide-split {
   --slide-split-padding-top: 64px;
   --slide-split-padding-bottom: 64px;
-}
 
-@media screen and (max-width: 1024px) {
-  deckgo-slide-split {
+  @media screen and (max-width: 1024px) {
     --slide-split-padding-top: 16px;
     --slide-split-padding-bottom: 16px;
   }
@@ -93,6 +88,11 @@ deckgo-deck deckgo-lazy-img {
   --deckgo-lazy-img-height: 100%;
   --deckgo-lazy-img-vertical-align: top;
   --deckgo-lazy-img-object-fit: contain;
+}
+
+deckgo-deck deckgo-slide-split deckgo-lazy-img[slot] {
+  --deckgo-lazy-img-height: auto;
+  --deckgo-lazy-img-max-height: 100%;
 }
 
 deckgo-deck deckgo-drr deckgo-lazy-img {

--- a/utils/deck/styles/deck/deck.scss
+++ b/utils/deck/styles/deck/deck.scss
@@ -42,27 +42,9 @@ deckgo-deck deckgo-lazy-img[slot] {
 
 /* Slide split */
 
-deckgo-slide-split > *[slot="start"],
-deckgo-slide-split > *[slot="end"] {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  word-break: break-word;
-}
-
-deckgo-slide-split[vertical] > *[slot="start"],
-deckgo-slide-split[vertical] > *[slot="end"] {
-  align-items: center;
-  text-align: center;
-}
-
-deckgo-slide-split > deckgo-highlight-code {
-  --deckgo-highlight-code-container-width: 100%;
-  --deckgo-highlight-code-container-height: 100%;
-  --deckgo-highlight-code-container-display: flex;
-  --deckgo-highlight-code-container-justify-content: center;
-  --deckgo-highlight-code-container-align-items: center;
-  --deckgo-highlight-code-container-flex-direction: column;
+deckgo-slide-split {
+  --slide-split-align: center;
+  --slide-split-text-align: center;
 }
 
 deckgo-slide-split {

--- a/utils/deck/styles/deck/fonts.scss
+++ b/utils/deck/styles/deck/fonts.scss
@@ -89,6 +89,8 @@ deckgo-deck p {
 // Font size if user modify sizes inside elements
 
 deckgo-deck font {
+  display: inline-block;
+
   &[size="1"] {
     font-size: 0.25em;
   }


### PR DESCRIPTION
If styling was applied as content of a column in the split slide, then the alignment was not preserver (everything was aligned left because of display flex-direction column)