### PR TITLE
fix: support offline access to the editor directly with the browser's url

### DIFF
--- a/studio/src/sw.js
+++ b/studio/src/sw.js
@@ -115,6 +115,13 @@ workbox.routing.registerRoute(
   })
 );
 
+workbox.routing.registerRoute(
+  /^(?=.*deckdeckgo\.com\/editor\/).*/,
+  new workbox.strategies.NetworkFirst({
+    cacheName: 'editor',
+  })
+);
+
 // the precache manifest will be injected into the following line
 self.workbox.precaching.precacheAndRoute([], {
   // Ignore all URL parameters otherwise /editor/:id won't be cached and therefore not accessible directly offline


### PR DESCRIPTION
Before this PR, if I go offline with the editor, turn off the wifi and refresh the browser's url or close Chrome and try to type the all url of my edited presentation (https://deckdeckgo.com/editor/:id) then it failed and displayed a 404.

With the help of this PR, the `/editor/:id/` path is cached with the help of a network first strategy and it solves the issue.

Note that in any case, the presentation still remains accessible through the root and navigation components (buttons).