### PR TITLE
Fix grammar mistake on app-landing-deck.tsx

### DIFF
--- a/studio/src/app/components/landing/app-landing-deck/app-landing-deck.tsx
+++ b/studio/src/app/components/landing/app-landing-deck/app-landing-deck.tsx
@@ -124,7 +124,7 @@ export class AppLandingDeck {
         <deckgo-slide-title>
           <h2 slot="title">Search Unsplash and Tenor GIFs.</h2>
           <h3 slot="content" style={{'font-weight': '300'}}>
-            Integrate easily Youtube video.
+            Easily integrate Youtube video.
           </h3>
 
           {this.renderSlideBackground(


### PR DESCRIPTION
Grammatical error from homepage: https://deckdeckgo.com/ -- slide number 4

Original text: 
> Integrate easily Youtube video.

Proposed change: 
> Easily integrate Youtube video.

---

<img src="https://user-images.githubusercontent.com/44626877/86234813-c6eb8100-bb97-11ea-837b-b1900bfdb2b2.jpg" alt="grammar" width="250" />

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `x`. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes

## Other information

<!-- Please provide any useful other information. -->

_no functional changes_

Issue Number: N/A
