### PR TITLE
infra: Read and inject header and footer

### DIFF
--- a/infra/handler/app/Test.hs
+++ b/infra/handler/app/Test.hs
@@ -173,6 +173,8 @@ testPresDeploys = withQueueName $ withEnv $ \env -> withSQS env $ withS3 env $ d
           , presentationOwner = someUserId
           , presentationAttributes = HMS.empty
           , presentationBackground = Nothing
+          , presentationHeader = Nothing
+          , presentationFooter = Nothing
           , presentationDescription = ""
           , presentationHeadExtra = Nothing
           }


### PR DESCRIPTION
This updates the API to read "header" and "footer" fields with are added
as `div`s with `slot = header` attributes.
