### PR TITLE
fix: componentdidload might be triggered twice with prerendering

### DIFF
--- a/studio/src/app/pages/core/app-settings/app-settings.tsx
+++ b/studio/src/app/pages/core/app-settings/app-settings.tsx
@@ -97,6 +97,8 @@ export class AppHome {
   }
 
   async componentDidLoad() {
+    this.destroyListener();
+
     const promises: Promise<void>[] = [this.initUser(), this.initApiUser()];
     await Promise.all(promises);
   }
@@ -122,6 +124,10 @@ export class AppHome {
   }
 
   componentDidUnload() {
+    this.destroyListener();
+  }
+
+  private destroyListener() {
     if (this.destroyUserListener) {
       this.destroyUserListener();
     }


### PR DESCRIPTION
It had side effect if user would change its avatar or custom logo more than once