### PR TITLE
fix: hide placeholder in fullscreen mode if idle

### DIFF
--- a/studio/src/global/theme/editor/editor-fullscreen.scss
+++ b/studio/src/global/theme/editor/editor-fullscreen.scss
@@ -34,36 +34,44 @@
 
   @import "./editor-fullscreen-footer";
 
+  app-editor {
+    main {
+      &.idle {
+        deckgo-deck {
+          h1,
+          h2,
+          h3,
+          section,
+          ol,
+          ul,
+          deckgo-reveal-list,
+          *:not([slot="background"]) > deckgo-lazy-img,
+          deckgo-reveal[img],
+          deckgo-math {
+            border: 1px solid transparent;
+
+            &:empty:not(:focus):after {
+              content: none;
+            }
+          }
+
+          [highlighted] {
+            box-shadow: none;
+          }
+        }
+
+        app-slide-contrast {
+          display: none;
+        }
+      }
+    }
+  }
+
   main {
     max-width: 100%;
 
     &.ready {
       box-shadow: none;
-    }
-
-    &.idle {
-      deckgo-deck {
-        h1,
-        h2,
-        h3,
-        section,
-        ol,
-        ul,
-        deckgo-reveal-list,
-        *:not([slot="background"]) > deckgo-lazy-img,
-        deckgo-reveal[img],
-        deckgo-math {
-          border: 1px solid transparent;
-        }
-
-        [highlighted] {
-          box-shadow: none;
-        }
-      }
-
-      app-slide-contrast {
-        display: none;
-      }
     }
 
     app-slide-contrast {


### PR DESCRIPTION
"Click to edit..." hidden in fullscreen mode if the deck is `.idle`