### PR TITLE
fix: sequential publish

### DIFF
--- a/cloud/functions/src/model/data/task.ts
+++ b/cloud/functions/src/model/data/task.ts
@@ -4,7 +4,7 @@ export interface TaskData {
   deckId: string;
   token: string | firestore.FieldValue;
 
-  type: 'publish-deck' | 'push-github';
+  type: 'publish-all' | 'publish-deck' | 'push-github';
 
   status: 'scheduled' | 'failure' | 'successful';
 

--- a/cloud/functions/src/watch/publish/publish.ts
+++ b/cloud/functions/src/watch/publish/publish.ts
@@ -65,7 +65,7 @@ function publishJob(snap: DocumentSnapshot): Promise<void> {
         // Therefore, to avoid such problem, we add a bit of delay in the process but only for the first publish
         setTimeout(
           async () => {
-            await publishToGitHub(deck.id, deck.data);
+            await delayPublishToGitHub(deck.id);
             resolve();
           },
           newPublish ? 5000 : 0
@@ -81,4 +81,19 @@ function publishJob(snap: DocumentSnapshot): Promise<void> {
       reject(err);
     }
   });
+}
+
+async function delayPublishToGitHub(deckId: string) {
+  // It has been changed by the publish to the API
+  const refreshDeck: Deck = await findDeck(deckId);
+
+  if (!refreshDeck || !refreshDeck.data) {
+    throw new Error('Updated published deck cannot be found');
+  }
+
+  try {
+    await publishToGitHub(refreshDeck.id, refreshDeck.data);
+  } catch (err) {
+    throw err;
+  }
 }

--- a/cloud/functions/src/watch/publish/publish.ts
+++ b/cloud/functions/src/watch/publish/publish.ts
@@ -68,7 +68,7 @@ function publishJob(snap: DocumentSnapshot): Promise<void> {
             await delayPublishToGitHub(deck.id);
             resolve();
           },
-          newPublish ? 5000 : 0
+          newPublish ? 7000 : 0
         );
       } else if (task.type === 'publish-deck') {
         await publishToApi(deck, task.token as string);


### PR DESCRIPTION
API first then GitHub (currently as we crawl the content from the published deck)