### PR TITLE
Saved previously used palette

### DIFF
--- a/studio/src/app/app-root.tsx
+++ b/studio/src/app/app-root.tsx
@@ -11,6 +11,7 @@ import {AuthService} from './services/auth/auth.service';
 import {ThemeService} from './services/theme/theme.service';
 import {OfflineService} from './services/editor/offline/offline.service';
 import {NavDirection, NavParams} from './stores/nav.store';
+import {PaletteService} from './services/palette/palette.service';
 
 @Component({
   tag: 'app-root',
@@ -22,6 +23,8 @@ export class AppRoot {
   private authService: AuthService;
 
   private themeService: ThemeService;
+
+  private paletteService: PaletteService;
 
   private offlineService: OfflineService;
 
@@ -37,6 +40,7 @@ export class AppRoot {
   constructor() {
     this.authService = AuthService.getInstance();
     this.themeService = ThemeService.getInstance();
+    this.paletteService = PaletteService.getInstance();
     this.offlineService = OfflineService.getInstance();
   }
 
@@ -44,6 +48,7 @@ export class AppRoot {
     if (Build.isBrowser) {
       await this.authService.init();
       await this.themeService.initDarkModePreference();
+      await this.paletteService.init();
       await this.offlineService.init();
     }
   }

--- a/studio/src/app/components/editor/styles/app-color-text-background/app-color-text-background.tsx
+++ b/studio/src/app/components/editor/styles/app-color-text-background/app-color-text-background.tsx
@@ -2,6 +2,8 @@ import {Component, Element, Event, EventEmitter, h, Method, Prop, State, Watch} 
 import {RangeChangeEventDetail} from '@ionic/core';
 
 import {ColorUtils, InitStyleColor} from '../../../../utils/editor/color.utils';
+import paletteStore from '../../../../stores/palette.store';
+import {colorInPaletteHandler} from '../../../../helpers/editor/palette.helper';
 
 @Component({
   tag: 'app-color-text-background',
@@ -68,6 +70,7 @@ export class AppColorTextBackground {
       return;
     }
 
+    paletteStore.state.palette = colorInPaletteHandler(paletteStore.state.palette, $event.detail);
     this.color = $event.detail.rgb;
 
     await this.applyColor();
@@ -188,6 +191,7 @@ export class AppColorTextBackground {
           </ion-item>
         </ion-list>
         <deckgo-color
+          palette={paletteStore.state.palette}
           class="ion-padding-start ion-padding-end ion-padding-bottom"
           more={this.moreColors}
           onColorChange={($event: CustomEvent) => this.selectColor($event)}

--- a/studio/src/app/components/editor/styles/element/app-color-code/app-color-code.tsx
+++ b/studio/src/app/components/editor/styles/element/app-color-code/app-color-code.tsx
@@ -5,6 +5,8 @@ import {alertController, RangeChangeEventDetail} from '@ionic/core';
 import {DeckdeckgoHighlightCodeCarbonTheme, DeckdeckgoHighlightCodeTerminal} from '@deckdeckgo/highlight-code';
 
 import {ColorUtils, InitStyleColor} from '../../../../../utils/editor/color.utils';
+import paletteStore from '../../../../../stores/palette.store';
+import {colorInPaletteHandler} from '../../../../../helpers/editor/palette.helper';
 
 enum CodeColorType {
   COMMENTS,
@@ -100,6 +102,8 @@ export class AppColorCode {
         resolve();
         return;
       }
+
+      paletteStore.state.palette = colorInPaletteHandler(paletteStore.state.palette, $event.detail);
 
       colorFunction($event);
 
@@ -394,6 +398,7 @@ export class AppColorCode {
 
           <div class={this.codeColorType === undefined ? 'ion-padding-start disabled' : 'ion-padding-start'}>
             <deckgo-color
+              palette={paletteStore.state.palette}
               class="ion-padding-bottom"
               onColorChange={($event: CustomEvent) => this.selectColor($event, this.setCodeColor)}
               color-rgb={this.codeColor}
@@ -509,6 +514,7 @@ export class AppColorCode {
 
           <div class={!this.highlightLines || this.highlightLines === undefined ? 'ion-padding-start disabled' : 'ion-padding-start'}>
             <deckgo-color
+              palette={paletteStore.state.palette}
               class="ion-padding-bottom"
               onColorChange={($event: CustomEvent) => this.selectColor($event, this.setHighlightColor)}
               color-rgb={this.highlightColor}

--- a/studio/src/app/components/editor/styles/slide/app-color-chart/app-color-chart.tsx
+++ b/studio/src/app/components/editor/styles/slide/app-color-chart/app-color-chart.tsx
@@ -5,6 +5,8 @@ import {SlideChartType} from '../../../../../models/data/slide';
 
 import {ColorUtils, InitStyleColor} from '../../../../../utils/editor/color.utils';
 import {ChartUtils} from '../../../../../utils/editor/chart.utils';
+import paletteStore from '../../../../../stores/palette.store';
+import {colorInPaletteHandler} from '../../../../../helpers/editor/palette.helper';
 
 enum ApplyColorType {
   FILL,
@@ -102,6 +104,7 @@ export class AppColorDeckSlide {
     if (!this.selectedElement || !$event || !$event.detail) {
       return;
     }
+    paletteStore.state.palette = colorInPaletteHandler(paletteStore.state.palette, $event.detail);
 
     this.color = $event.detail.rgb;
 
@@ -228,6 +231,7 @@ export class AppColorDeckSlide {
       </ion-item>,
 
       <deckgo-color
+        palette={paletteStore.state.palette}
         class="ion-padding-start ion-padding-end ion-padding-bottom"
         more={this.moreColors}
         onColorChange={($event: CustomEvent) => this.selectColor($event)}

--- a/studio/src/app/components/editor/styles/slide/app-color-qrcode/app-color-qrcode.tsx
+++ b/studio/src/app/components/editor/styles/slide/app-color-qrcode/app-color-qrcode.tsx
@@ -2,6 +2,8 @@ import {Component, Element, Event, EventEmitter, h, Method, Prop, State} from '@
 import {RangeChangeEventDetail} from '@ionic/core';
 
 import {ColorUtils, InitStyleColor} from '../../../../../utils/editor/color.utils';
+import paletteStore from '../../../../../stores/palette.store';
+import {colorInPaletteHandler} from '../../../../../helpers/editor/palette.helper';
 
 enum ApplyColorType {
   QR_CODE,
@@ -71,6 +73,7 @@ export class AppColorQRCode {
     if (!this.selectedElement || !$event || !$event.detail) {
       return;
     }
+    paletteStore.state.palette = colorInPaletteHandler(paletteStore.state.palette, $event.detail);
 
     this.color = $event.detail.rgb;
 
@@ -178,6 +181,7 @@ export class AppColorQRCode {
         </ion-item>
       </ion-list>,
       <deckgo-color
+        palette={paletteStore.state.palette}
         class="ion-padding-start ion-padding-end ion-padding-bottom"
         more={this.moreColors}
         onColorChange={($event: CustomEvent) => this.selectColor($event)}

--- a/studio/src/app/components/editor/styles/slide/app-color-sides/app-color-sides.tsx
+++ b/studio/src/app/components/editor/styles/slide/app-color-sides/app-color-sides.tsx
@@ -2,6 +2,8 @@ import {Component, Element, Event, EventEmitter, h, Method, Prop, State} from '@
 import {RangeChangeEventDetail} from '@ionic/core';
 
 import {ColorUtils, InitStyleColor} from '../../../../../utils/editor/color.utils';
+import paletteStore from '../../../../../stores/palette.store';
+import {colorInPaletteHandler} from '../../../../../helpers/editor/palette.helper';
 
 enum ApplyColorType {
   FONT,
@@ -77,6 +79,7 @@ export class AppColorSides {
     if (!this.selectedElement || !$event || !$event.detail) {
       return;
     }
+    paletteStore.state.palette = colorInPaletteHandler(paletteStore.state.palette, $event.detail);
 
     this.color = $event.detail.rgb;
 
@@ -199,6 +202,7 @@ export class AppColorSides {
         </ion-item>
       </ion-list>,
       <deckgo-color
+        palette={paletteStore.state.palette}
         class="ion-padding-start ion-padding-end ion-padding-bottom"
         more={this.moreColors}
         onColorChange={($event: CustomEvent) => this.selectColor($event)}

--- a/studio/src/app/helpers/editor/palette.helper.ts
+++ b/studio/src/app/helpers/editor/palette.helper.ts
@@ -1,7 +1,6 @@
 import {DeckdeckgoPalette, DeckdeckgoPaletteColor} from '@deckdeckgo/color';
 
 export function colorInPaletteHandler(currentPalette: DeckdeckgoPalette[], color: DeckdeckgoPaletteColor) {
-  console.log(currentPalette, color);
   if (currentPalette) {
     if (currentPalette.some((palette) => palette.color.hex === color.hex)) return currentPalette;
     return [{color}, ...currentPalette];

--- a/studio/src/app/helpers/editor/palette.helper.ts
+++ b/studio/src/app/helpers/editor/palette.helper.ts
@@ -1,0 +1,9 @@
+import {DeckdeckgoPalette, DeckdeckgoPaletteColor} from '@deckdeckgo/color';
+
+export function colorInPaletteHandler(currentPalette: DeckdeckgoPalette[], color: DeckdeckgoPaletteColor) {
+  console.log(currentPalette, color);
+  if (currentPalette) {
+    if (currentPalette.some((palette) => palette.color.hex === color.hex)) return currentPalette;
+    return [{color}, ...currentPalette];
+  }
+}

--- a/studio/src/app/services/palette/palette.service.tsx
+++ b/studio/src/app/services/palette/palette.service.tsx
@@ -19,19 +19,10 @@ export class PaletteService {
   async init() {
     try {
       const palette = await get<DeckdeckgoPalette[]>('deckdeckgo_palette');
-      paletteStore.state.palette = palette;
+      paletteStore.state.palette = palette ?? DEFAULT_PALETTE;
     } catch (err) {
       console.warn("Couldn't find stored palette. Proceeding with default");
       paletteStore.state.palette = DEFAULT_PALETTE;
-    }
-  }
-  async updatePalette(palette: DeckdeckgoPalette[]) {
-    paletteStore.state.palette = palette;
-
-    try {
-      await set('deckdeckgo_palette', palette);
-    } catch (err) {
-      console.error('Failed to update IDB with new palette');
     }
   }
 }

--- a/studio/src/app/services/palette/palette.service.tsx
+++ b/studio/src/app/services/palette/palette.service.tsx
@@ -1,0 +1,37 @@
+import paletteStore from '../../stores/palette.store';
+
+import {get, set} from 'idb-keyval';
+import {DeckdeckgoPalette, DEFAULT_PALETTE} from '@deckdeckgo/color';
+
+export class PaletteService {
+  private static instance: PaletteService;
+
+  private constructor() {
+    // Private constructor, singleton
+  }
+
+  static getInstance() {
+    if (!PaletteService.instance) {
+      PaletteService.instance = new PaletteService();
+    }
+    return PaletteService.instance;
+  }
+  async init() {
+    try {
+      const palette = await get<DeckdeckgoPalette[]>('deckdeckgo_palette');
+      paletteStore.state.palette = palette;
+    } catch (err) {
+      console.warn("Couldn't find stored palette. Proceeding with default");
+      paletteStore.state.palette = DEFAULT_PALETTE;
+    }
+  }
+  async updatePalette(palette: DeckdeckgoPalette[]) {
+    paletteStore.state.palette = palette;
+
+    try {
+      await set('deckdeckgo_palette', palette);
+    } catch (err) {
+      console.error('Failed to update IDB with new palette');
+    }
+  }
+}

--- a/studio/src/app/stores/palette.store.ts
+++ b/studio/src/app/stores/palette.store.ts
@@ -1,12 +1,18 @@
-import {DeckdeckgoPalette} from '@deckdeckgo/color/dist/types/utils/deckdeckgo-palette';
+import {DeckdeckgoPalette} from '@deckdeckgo/color';
 import {createStore} from '@stencil/store';
+import {set} from 'idb-keyval';
 
 interface PaletteStore {
   palette: DeckdeckgoPalette[];
 }
 
-const {state} = createStore<PaletteStore>({
+const {state, onChange} = createStore<PaletteStore>({
   palette: [],
 });
 
-export default {state};
+onChange('palette', (palette) => {
+  set('deckdeckgo_palette', palette).catch((err) => {
+    console.error('Failed to update IDB with new palette', err);
+  });
+});
+export default {state, onChange};

--- a/studio/src/app/stores/palette.store.ts
+++ b/studio/src/app/stores/palette.store.ts
@@ -1,0 +1,12 @@
+import {DeckdeckgoPalette} from '@deckdeckgo/color/dist/types/utils/deckdeckgo-palette';
+import {createStore} from '@stencil/store';
+
+interface PaletteStore {
+  palette: DeckdeckgoPalette[];
+}
+
+const {state} = createStore<PaletteStore>({
+  palette: [],
+});
+
+export default {state};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR adds support for backing up changes made in custom-colors for the `deckgo-color`-component.
The backed up palette is stored in indexDB and initialized from that same store with the help of a paletteService
<!-- Please check the one that applies to this PR using `x`. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes

## Other information

<!-- Please provide any useful other information. -->

Issue Number: #902 
