### PR TITLE
Default minimized editor-panel in fullscreen mode

### DIFF
--- a/studio/src/app/components/editor/actions/app-actions-editor/app-actions-editor.scss
+++ b/studio/src/app/components/editor/actions/app-actions-editor/app-actions-editor.scss
@@ -56,28 +56,32 @@ app-actions-editor {
 
   &.fullscreen {
     transition: opacity 0.3s ease;
-    opacity: 0.3;
+    opacity: 0.2;
 
     &:hover {
       opacity: 1;
-      app-breadcrumbs {
-        display: initial;
-      }
-      button > ion-label {
+
+      ion-toolbar button > ion-label {
         height: 100%;
         opacity: 1;
+        margin: initial;
       }
-      div.indicator > app-breadcrumbs {
-        display: initial;
+      div.indicator {
+        padding-top: 8px;
+        margin: initial;
+        & > app-breadcrumbs {
+          display: initial;
+        }
       }
     }
-    ion-toolbar {
+    ion-toolbar button > ion-label {
+      height: 0;
       opacity: 0;
-      height: 0%;
+      margin: 0;
     }
-
     div.indicator {
-      padding-top: 8px;
+      padding-top: 0;
+      margin: 0;
       & > app-breadcrumbs {
         display: none;
       }

--- a/studio/src/app/components/editor/actions/app-actions-editor/app-actions-editor.scss
+++ b/studio/src/app/components/editor/actions/app-actions-editor/app-actions-editor.scss
@@ -55,8 +55,32 @@ app-actions-editor {
   }
 
   &.fullscreen {
+    transition: opacity 0.3s ease;
+    opacity: 0.3;
+
+    &:hover {
+      opacity: 1;
+      app-breadcrumbs {
+        display: initial;
+      }
+      button > ion-label {
+        height: 100%;
+        opacity: 1;
+      }
+      div.indicator > app-breadcrumbs {
+        display: initial;
+      }
+    }
+    ion-toolbar {
+      opacity: 0;
+      height: 0%;
+    }
+
     div.indicator {
       padding-top: 8px;
+      & > app-breadcrumbs {
+        display: none;
+      }
     }
   }
 

--- a/studio/src/app/components/editor/actions/app-actions-editor/app-actions-editor.tsx
+++ b/studio/src/app/components/editor/actions/app-actions-editor/app-actions-editor.tsx
@@ -122,7 +122,10 @@ export class AppActionsEditor {
   private renderDeckActions() {
     return (
       <app-actions-deck
-        class={this.step != BreadcrumbsStep.DECK ? 'hidden' : undefined}
+        class={{
+          hidden: this.step != BreadcrumbsStep.DECK,
+          fullscreen: this.fullscreen,
+        }}
         fullscreen={this.fullscreen}
         slides={this.slides}
         blockSlide={this.blockSlide}

--- a/studio/src/app/pages/editor/app-editor/app-editor.tsx
+++ b/studio/src/app/pages/editor/app-editor/app-editor.tsx
@@ -562,7 +562,6 @@ export class AppEditor {
 
       await this.editorEventsHandler.selectDeck();
       await (deck as any).toggleFullScreen();
-
       resolve();
     });
   }

--- a/utils/utils/src/utils/utils.ts
+++ b/utils/utils/src/utils/utils.ts
@@ -55,11 +55,10 @@ export function isIPad(): boolean {
 }
 
 export function isFullscreen(): boolean {
-  if (!window || !screen) {
+  if (!document) {
     return false;
   }
-
-  return window.innerHeight == screen.height;
+  return document.fullscreenElement !== null;
 }
 
 export function isFirefox(): boolean {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR sets a default for how th editor-panel is displayed while in fullscreen mode.
The panel is displayed with a lower opacity and without text when in fullscreen mode:
![Screenshot from 2020-10-04 12-40-47](https://user-images.githubusercontent.com/17365954/95013186-f5697400-063e-11eb-83ba-39ef04a7e606.png)
But as soon as the user hovers over the menu it will transition back to normal.

I also noticed that the helperfunction for checking if the device was in fullscreen mode didn't work for my device.
I debugged and implemented another way (which I think is safer) to check if the device is in fullscreen mode.
<!-- Please check the one that applies to this PR using `x`. -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes

## Other information

<!-- Please provide any useful other information. -->

Issue Number: #901 
