### PR TITLE
add: overflow hidden for font item

### DIFF
--- a/studio/src/app/components/editor/styles/deck/app-deck-fonts/app-deck-fonts.scss
+++ b/studio/src/app/components/editor/styles/deck/app-deck-fonts/app-deck-fonts.scss
@@ -21,6 +21,7 @@ app-deck-fonts {
       border: 2px solid var(--ion-color-light);
 
       font-size: var(--font-size-normal);
+      overflow: hidden;
 
       width: 100%;
       height: 5rem;


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Other information

Overflow of font item container fixed by adding hidden property for overflow.

Issue Number: #882 
