### PR TITLE
fix(a11y): show border when colors are focused by keyboard

### DIFF
--- a/studio/src/app/components/editor/styles/app-color/app-color.scss
+++ b/studio/src/app/components/editor/styles/app-color/app-color.scss
@@ -102,6 +102,10 @@ app-color {
         display: block;
         padding: 8px;
       }
+
+      &.ion-focused {
+        outline: 1px solid rgba(var(--ion-color-primary-rgb), 0.4);
+      }
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `x` and remove the others. -->

- [x] Bugfix

## Other information
I think we might need to change more items so that they are visually seen focussed.

![image-](https://user-images.githubusercontent.com/1763537/98291543-92575e00-1fab-11eb-9b2b-e10f5c3b339b.jpg)


 I used the same color as the outline color for title/subtitle in the first slide. Feel free to let me know which color to choose.

Issue Number: #997 
