### PR TITLE
fix(a11y): improve font color focus state

### DIFF
--- a/studio/src/app/components/editor/styles/app-color/app-color.scss
+++ b/studio/src/app/components/editor/styles/app-color/app-color.scss
@@ -33,6 +33,10 @@ app-color {
       &::-webkit-color-swatch {
         border: none;
       }
+
+      &:focus {
+        outline: 1px solid rgba(var(--ion-color-primary-rgb), 0.4);
+      }
     }
 
     button {
@@ -50,6 +54,11 @@ app-color {
         display: flex;
         justify-content: center;
         align-items: center;
+      }
+
+      &:focus {
+        outline: 1px solid rgba(var(--ion-color-primary-rgb), 0.4);
+        outline-offset: -1px;
       }
     }
 
@@ -111,5 +120,12 @@ app-color {
 
   ion-range {
     --bar-background: var(--ion-color-light);
+  }
+
+  .item-opacity {
+    &.ion-focused {
+      outline: 1px solid rgba(var(--ion-color-primary-rgb), 0.4);
+      outline-offset: -1px;
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `x` and remove the others. -->

- [x] Bugfix

## Other information

It will improve and standardize the focusing with keyboard of the font color selection.

**GIF of before state**

![before-gif](https://user-images.githubusercontent.com/1763537/98442500-4fa99900-2105-11eb-9ba1-44238d016620.gif)

**GIF of after state**

![focus-gif](https://user-images.githubusercontent.com/1763537/98442512-5fc17880-2105-11eb-93a1-e3de77b2aef7.gif)

Related to #998 