### PR TITLE
enhancement(markdown): updating markdown worker to identify width and height

### DIFF
--- a/webcomponents/markdown/src/components/workers/utils/markdown-img.utils.ts
+++ b/webcomponents/markdown/src/components/workers/utils/markdown-img.utils.ts
@@ -1,26 +1,14 @@
 import marked from 'marked';
 
 // Source: https://github.com/markedjs/marked/issues/339
-// ![](https://www.nmattia.com/images/autoupdate-notifications.jpg "=100px,20px")
-// ![](https://www.nmattia.com/images/autoupdate-notifications.jpg "=100px")
-// ![](https://www.nmattia.com/images/autoupdate-notifications.jpg)
-
+// ![](https://www.nmattia.com/images/autoupdate-notifications.jpg "width:100px,height:20px")
 export function changeImgCreation(renderer: marked.Renderer) {
   renderer.image = (src: string | null, title: string | null, alt: string) => {
-    const exec = /=\s*(\d*(?:px|em|ex|ch|rem|vw|vh|vmin|vmax|%))\s*,*\s*(\d*(?:px|em|ex|ch|rem|vw|vh|vmin|vmax|%))*\s*$/.exec(title);
-
-    let style: string = '';
-    if (exec) {
-      if (exec[1]) {
-        style += `--deckgo-lazy-img-width: ${exec[1].replace(',', '')};`;
-      }
-
-      if (exec[2]) {
-        style += `--deckgo-lazy-img-height: ${exec[2].replace(',', '')};`;
-      }
+    const getWidthAndHeightStyle = checkForWidthAndHeight(title);
+    if (getWidthAndHeightStyle.length) {
+      return `<deckgo-lazy-img img-src="${sanitize(src)}" img-alt="${sanitize(alt)}" style="${getWidthAndHeightStyle}"></deckgo-lazy-img>`;
     }
-
-    return `<deckgo-lazy-img img-src="${sanitize(src)}" img-alt="${sanitize(alt)}" style="${style}"></deckgo-lazy-img>`;
+    return `<deckgo-lazy-img img-src="${sanitize(src)}" img-alt="${sanitize(alt)}"></deckgo-lazy-img>`;
   };
 }
 
@@ -31,3 +19,16 @@ function sanitize(str: string) {
     return '&quot;';
   });
 }
+
+function checkForWidthAndHeight(title) {
+  const isWidthSet = /width:\d+px/.exec(title);
+  const isHeightSet = /height:\d+px/.exec(title);
+  let style: string = '';
+  if(!!(isWidthSet && isHeightSet)){
+    const width = /\d+px/.exec(isWidthSet[0])[0];
+    const height = /\d+px/.exec(isHeightSet[0])[0];
+    style += `--deckgo-lazy-img-width: ${width};`;
+    style += `--deckgo-lazy-img-height: ${height};`;
+  }
+  return style;
+};

--- a/webcomponents/markdown/src/index.html
+++ b/webcomponents/markdown/src/index.html
@@ -33,8 +33,8 @@
 <br/>
 [Link](https://deckdeckgo.com/)
 <br/>
-![](https://www.nmattia.com/images/autoupdate-notifications.jpg "=100px,20px")
-![](https://www.nmattia.com/images/autoupdate-notifications.jpg "=100px")
+![](https://www.nmattia.com/images/autoupdate-notifications.jpg "width:100px,height:20px")
+![](https://www.nmattia.com/images/autoupdate-notifications.jpg "width:300px,height:200px")
 ![](https://www.nmattia.com/images/autoupdate-notifications.jpg)
 <br/>
 This is basic paragraph with some **bold text** and also some *italic text*.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ 👎 ] Tests for the changes have been added (for bug fixes / features)
- [ 👎 ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Updated the functionality of the of the markdown worker to look for width and height for images. If width and height exists then it will add those measurements to the deck deck go img and return. 
<!-- Please check the one that applies to this PR using `x` and remove the others. -->

- [ X] Feature

## Other information

<!-- Please provide any useful other information. -->

Issue Number: 1007
