### PR TITLE
feat: limit resize to container height and width 

### DIFF
--- a/webcomponents/drag-resize-rotate/src/components/deckdeckgo-drr.tsx
+++ b/webcomponents/drag-resize-rotate/src/components/deckdeckgo-drr.tsx
@@ -435,8 +435,17 @@ export class DeckdeckgoDragResizeRotate {
       h = htmp;
     }
 
-    const l: number = matrix.c * q_x + matrix.a * p_x;
-    const t: number = matrix.d * q_y + matrix.b * p_y;
+    let l: number = matrix.c * q_x + matrix.a * p_x;
+    let t: number = matrix.d * q_y + matrix.b * p_y;
+
+    l = l < 0 ? 0 : l;
+    t = t < 0 ? 0 : t;
+
+    const maxLeft: number = this.parentWidth - l;
+    const maxTop: number = this.parentHeight - t;
+
+    w = w > maxLeft ? maxLeft : w;
+    h = h > maxTop ? maxTop : h;
 
     this.left = this.convertToUnit(l, 'width');
     this.width = this.convertToUnit(w, 'width');


### PR DESCRIPTION
Limit the resize top, left, width and height to the parent container height and width 

Signed-off-by: Matheus Cerqueira <matheus.abrantesc@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Other information


Issue Number: N/A
