### PR TITLE
infra: drop static-haskell-nix and update nixpkgs

### DIFF
--- a/infra/default.nix
+++ b/infra/default.nix
@@ -1,7 +1,11 @@
-with { pkgs = import ./nix {}; };
+let
+  pkgs = import ./nix {};
+  napalm = import pkgs.sources.napalm { inherit pkgs;} ;
+in
 
 rec
-{ function = # TODO: rename to handler
+{
+  function = # TODO: rename to handler
     pkgs.runCommand "build-lambda" {}
       ''
         cp ${./main.js} main.js
@@ -59,9 +63,10 @@ rec
         ${pkgs.zip}/bin/zip -r $out/function.zip main.js main_hs
       '';
 
+
+  deckdeckgo-starter-dist-foo = napalm.buildPackage pkgs.sources.deckdeckgo-starter {};
+
   deckdeckgo-starter-dist =
-    with
-      { napalm = import pkgs.sources.napalm { inherit pkgs;} ; };
     pkgs.runCommand "deckdeckgo-starter" { buildInputs = [ pkgs.nodejs pkgs.zip ]; }
       ''
         cp -r ${napalm.buildPackage pkgs.sources.deckdeckgo-starter {}}/* .
@@ -75,9 +80,9 @@ rec
         popd
       '';
 
-  devshell = if ! pkgs.lib.inNixShell then null else
-    with
-      { pkg = pkgs.haskellPackages.developPackage { root = ./handler; } ; };
+
+  devshell =
+    let pkg = handler.env; in
     pkg.overrideAttrs(attr: {
       buildInputs = with pkgs;
         [ terraform awscli postgresql moreutils minio ];
@@ -166,11 +171,12 @@ rec
         '';
      });
 
-  handler = pkgs.haskellPackages.deckdeckgo-handler;
+  handler = pkgs.staticHaskellPackages.deckdeckgo-handler;
+  firebase-login = pkgs.staticHaskellPackages.firebase-login;
 
-  unsplashProxy = pkgs.haskellPackages.unsplash-proxy;
+  unsplashProxy = pkgs.staticHaskellPackages.unsplash-proxy;
 
-  googleKeyUpdater = pkgs.haskellPackages.google-key-updater;
+  googleKeyUpdater = pkgs.staticHaskellPackages.google-key-updater;
 
   publicKey = builtins.readFile ./public.cer;
 

--- a/infra/firebase-login/default.nix
+++ b/infra/firebase-login/default.nix
@@ -1,5 +1,18 @@
-# TODO: port tests
-# TODO: fix sources
-# TODO: drop nix/packages
-with { pkgs = import ./nix {}; };
-pkgs.callPackage ./nix/packages.nix {}
+{ mkDerivation, aeson, base, bytestring, hpack, http-client
+, http-client-tls, http-conduit, jose, lens, mtl, network-uri, pem
+, servant, servant-client-core, servant-server, servant-swagger
+, stdenv, text, unordered-containers, wai, word8, x509
+}:
+mkDerivation {
+  pname = "firebase-login";
+  version = "0.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson base bytestring http-client http-client-tls http-conduit jose
+    lens mtl network-uri pem servant servant-client-core servant-server
+    servant-swagger text unordered-containers wai word8 x509
+  ];
+  libraryToolDepends = [ hpack ];
+  prePatch = "hpack";
+  license = stdenv.lib.licenses.mit;
+}

--- a/infra/firebase-login/nix/default.nix
+++ b/infra/firebase-login/nix/default.nix
@@ -2,10 +2,6 @@
 with
   { overlay = _: pkgs: rec
       { inherit (import sources.niv {}) niv;
-        haskellPackages = pkgs.haskellPackages.override
-          { overrides = _: super:
-              { jose = super.callCabal2nix "jose" sources.hs-jose {}; };
-          };
 
         packages = import ./packages.nix
           { inherit (pkgs) haskell lib ;

--- a/infra/firebase-login/nix/packages.nix
+++ b/infra/firebase-login/nix/packages.nix
@@ -7,7 +7,7 @@
 }:
 rec
 { firebase-login-sdist = haskell.lib.sdistTarball firebase-login;
-  firebase-login = haskellPackages.callCabal2nix "firebase-login" firebase-login-source {};
+  firebase-login = haskellPackages.callPackage ../../firebase-login {};
   firebase-login-source = lib.sourceByRegex ../.
     [ "^package.yaml$"
       "^src.*"

--- a/infra/firebase-login/shell.nix
+++ b/infra/firebase-login/shell.nix
@@ -1,5 +1,5 @@
-with { pkgs = import ./nix {}; };
-pkgs.haskellPackages.developPackage
-  { root = ./.;
-    modifier = drv: drv // { buildInputs = drv.buildInputs ++ [ pkgs.cabal-install ]; } ;
-  }
+with { pkgs = import ../nix {}; };
+
+pkgs.haskellPackages.firebase-login.env.overrideAttrs(oldAttrs: {
+  nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [ pkgs.cabal-install ];
+})

--- a/infra/firebase-login/src/Servant/Auth/Firebase.hs
+++ b/infra/firebase-login/src/Servant/Auth/Firebase.hs
@@ -35,7 +35,7 @@ import qualified Network.Wai as Wai
 import qualified Servant as Servant
 import qualified Servant.Client.Core as Servant
 import qualified Servant.Client.Core as Servant.Client
-import qualified Servant.Server.Internal.RoutingApplication as Servant
+import qualified Servant.Server.Internal as Servant
 
 data Protected
 

--- a/infra/google-key-updater/default.nix
+++ b/infra/google-key-updater/default.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, amazonka, amazonka-core, amazonka-s3, base
+, bytestring, hpack, http-client, http-client-tls, http-conduit
+, http-types, servant, servant-client, servant-server, stdenv, text
+, unliftio, wai, wai-cors, wai-lambda, warp, pkgsMusl
+}:
+mkDerivation {
+  pname = "google-key-updater";
+  version = "0.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    aeson amazonka amazonka-core amazonka-s3 base bytestring
+    http-client http-client-tls http-conduit http-types servant
+    servant-client servant-server text unliftio wai wai-cors wai-lambda
+    warp
+  ];
+  prePatch = "hpack";
+  license = stdenv.lib.licenses.agpl3;
+  configureFlags = [
+          "--ghc-option=-optl=-static"
+          "--extra-lib-dirs=${pkgsMusl.gmp6.override { withStatic = true; }}/lib"
+          "--extra-lib-dirs=${pkgsMusl.zlib.static}/lib"
+          "--extra-lib-dirs=${pkgsMusl.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
+    ];
+}

--- a/infra/handler/app/Test.hs
+++ b/infra/handler/app/Test.hs
@@ -328,7 +328,7 @@ testServer = withServer $ \port -> do
 
   runClientM (usersPost' b someUserInfo) clientEnv >>= \case
     -- TODO: test that user is returned here, even on 409
-    Left (FailureResponse resp) ->
+    Left (FailureResponse _ resp) ->
       if HTTP.statusCode (responseStatusCode resp) == 409 then pure () else
         error $ "Got unexpected response: " <> show resp
     Left e -> error $ "Expected 409, got error: " <> show e

--- a/infra/handler/default.nix
+++ b/infra/handler/default.nix
@@ -1,0 +1,50 @@
+{ mkDerivation, aeson, amazonka, amazonka-cloudfront, amazonka-core
+, amazonka-s3, amazonka-sqs, base, bytestring, cases, conduit
+, conduit-extra, contravariant, cryptonite, directory, filepath
+, firebase-login, hasql, hpack, http-client, http-client-tls
+, http-types, lens, memory, mime-types, mtl, port-utils, pureMD5
+, random, resourcet, servant, servant-client, servant-server
+, servant-swagger, servant-swagger-ui, stdenv, swagger2, tagsoup
+, tasty, tasty-hunit, temporary, text, time, unliftio
+, unordered-containers, wai, wai-cors, wai-lambda, warp
+, zip-archive, pkgsMusl
+}:
+mkDerivation {
+  pname = "deckdeckgo-handler";
+  version = "0.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  enableLibraryProfiling = false;
+  enableExecutableProfiling = false;
+  enableSharedExecutables = false;
+  enableSharedLibraries = false;
+  libraryHaskellDepends = [
+    aeson amazonka amazonka-cloudfront amazonka-core amazonka-s3
+    amazonka-sqs base bytestring cases conduit conduit-extra
+    contravariant cryptonite directory filepath firebase-login hasql
+    http-client http-types lens memory mime-types mtl pureMD5 random
+    resourcet servant servant-server servant-swagger servant-swagger-ui
+    swagger2 tagsoup temporary text time unliftio unordered-containers
+    wai wai-cors wai-lambda zip-archive
+  ];
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    aeson amazonka amazonka-cloudfront amazonka-core amazonka-s3
+    amazonka-sqs base bytestring cases conduit conduit-extra
+    contravariant cryptonite directory filepath firebase-login hasql
+    http-client http-client-tls http-types lens memory mime-types mtl
+    port-utils pureMD5 random resourcet servant servant-client
+    servant-server servant-swagger servant-swagger-ui swagger2 tagsoup
+    tasty tasty-hunit temporary text time unliftio unordered-containers
+    wai wai-cors wai-lambda warp zip-archive
+  ];
+  prePatch = "hpack";
+  license = stdenv.lib.licenses.agpl3;
+  configureFlags = [
+          "--ghc-option=-optl=-static"
+          "--extra-lib-dirs=${pkgsMusl.gmp6.override { withStatic = true; }}/lib"
+          "--extra-lib-dirs=${pkgsMusl.zlib.static}/lib"
+          "--extra-lib-dirs=${pkgsMusl.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
+    ];
+}

--- a/infra/handler/package.yaml
+++ b/infra/handler/package.yaml
@@ -48,6 +48,10 @@ dependencies:
 
 ghc-options:
     - -Wall
+    - -optl
+    - -Wl,--start-group
+    - -lssl
+    - -lcrypto
 
 library:
     source-dirs: src

--- a/infra/nix/sources.json
+++ b/infra/nix/sources.json
@@ -17,18 +17,6 @@
         "url": "https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.6.jar",
         "url_template": "https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.6.jar"
     },
-    "hs-jose": {
-        "branch": "master",
-        "description": "Haskell JOSE and JWT library",
-        "homepage": "http://hackage.haskell.org/package/jose",
-        "owner": "frasertweedale",
-        "repo": "hs-jose",
-        "rev": "71274bf64c0600c1d877152173a08a5bff7adf4d",
-        "sha256": "0ah189vika1s0jk8f17mn77gilkw24vbs6xlggxw1qj926i6c4pk",
-        "type": "tarball",
-        "url": "https://github.com/frasertweedale/hs-jose/archive/71274bf64c0600c1d877152173a08a5bff7adf4d.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "napalm": {
         "branch": "master",
         "description": "Support for building npm packages in Nix and lightweight npm registry",
@@ -41,28 +29,16 @@
         "url": "https://github.com/nmattia/napalm/archive/4db4f253c78cfa8d8e8defb45dfe25e04409142a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "niv": {
-        "branch": "master",
-        "description": "Easy dependency management for Nix projects",
-        "homepage": "https://github.com/nmattia/niv",
-        "owner": "nmattia",
-        "repo": "niv",
-        "rev": "c2698b0780b783880e0b1a520723948fe3b5c26a",
-        "sha256": "0v68x0h9si6kjqg5fcjrgsbsf4x18m32a786yvjmrdkrki9qwmcq",
-        "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/c2698b0780b783880e0b1a520723948fe3b5c26a.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "release-20.03",
         "description": "Nixpkgs/NixOS branches that track the Nixpkgs/NixOS channels",
         "homepage": null,
-        "owner": "nh2",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2d7e9b875e8ba7fd15b989cf2d80be4e183dc72",
-        "sha256": "1hnmp637r99qd6g0sbx4w3za564gbzwl5c4z0x7fvn7kfi2jp1hx",
+        "rev": "504f993df9a5ca63317fe9c859df19daad30aa14",
+        "sha256": "19innk4v45xq62q6n5h0alhfbb3v7yxpdd1r7sglgjn8sr3ylwmn",
         "type": "tarball",
-        "url": "https://github.com/nh2/nixpkgs/archive/a2d7e9b875e8ba7fd15b989cf2d80be4e183dc72.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/504f993df9a5ca63317fe9c859df19daad30aa14.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "port-utils": {
@@ -70,28 +46,5 @@
         "type": "tarball",
         "url": "http://hackage.haskell.org/package/port-utils-0.2.1.0/port-utils-0.2.1.0.tar.gz",
         "url_template": "http://hackage.haskell.org/package/port-utils-0.2.1.0/port-utils-0.2.1.0.tar.gz"
-    },
-    "static-haskell-nix": {
-        "branch": "master",
-        "description": "easily build most Haskell programs into fully static Linux executables",
-        "homepage": "",
-        "owner": "nh2",
-        "repo": "static-haskell-nix",
-        "rev": "8d004d7ced9da947c785b93b4011f39367442339",
-        "sha256": "0nw4g23c5rs0cvaar2phpr60zim9r0qycznpifi8d8k85y4r3bdd",
-        "type": "tarball",
-        "url": "https://github.com/nh2/static-haskell-nix/archive/8d004d7ced9da947c785b93b4011f39367442339.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "wai-lambda": {
-        "branch": "master",
-        "description": "Haskell Webapps on AWS Lambda",
-        "owner": "deckgo",
-        "repo": "wai-lambda",
-        "rev": "7f139047addff89e9d30e55b7eebb07c0e846456",
-        "sha256": "0qqi6wlg8v35dkh6gh9mrj0kb9kpzrz2pc7k0dykk2ahcj6m22k6",
-        "type": "tarball",
-        "url": "https://github.com/deckgo/wai-lambda/archive/7f139047addff89e9d30e55b7eebb07c0e846456.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/infra/unsplash-proxy/Main.hs
+++ b/infra/unsplash-proxy/Main.hs
@@ -54,7 +54,7 @@ type ClientAPI =
 runClient
   :: MonadIO io
   => Client.ClientM a
-  -> io (Either Client.ServantError a)
+  -> io (Either Client.ClientError a)
 runClient act = liftIO $ do
     mgr <- HTTP.newManager HTTP.tlsManagerSettings
     Client.runClientM act (clientEnv mgr)

--- a/infra/unsplash-proxy/default.nix
+++ b/infra/unsplash-proxy/default.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, aeson, base, bytestring, hpack, http-client
+, http-client-tls, http-conduit, http-types, servant
+, servant-client, servant-server, stdenv, text, wai, wai-cors
+, wai-lambda, warp, pkgsMusl
+}:
+mkDerivation {
+  pname = "unsplash-proxy";
+  version = "0.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    aeson base bytestring http-client http-client-tls http-conduit
+    http-types servant servant-client servant-server text wai wai-cors
+    wai-lambda warp
+  ];
+  prePatch = "hpack";
+  license = stdenv.lib.licenses.agpl3;
+  configureFlags = [
+          "--ghc-option=-optl=-static"
+          "--extra-lib-dirs=${pkgsMusl.gmp6.override { withStatic = true; }}/lib"
+          "--extra-lib-dirs=${pkgsMusl.zlib.static}/lib"
+          "--extra-lib-dirs=${pkgsMusl.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
+    ];
+}


### PR DESCRIPTION
This drops `static-haskell-nix` and `callCabal2nix`, making our setup
much simpler. This also includes a pretty big jump forward in terms of
Haskell deps.
