### PR TITLE
chore: add open collective sponsor

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: deckdeckgo


### PR DESCRIPTION
Displays the sponsorship button linked with our newly created open collective.