### PR TITLE
Adds button to deactivate low contrast warnings

### DIFF
--- a/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
+++ b/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
@@ -205,7 +205,7 @@ export class AppSlideWarning {
     const popover: HTMLIonPopoverElement = await popoverController.create({
       component: 'app-slide-warning-info',
       componentProps: {
-        lowContrast: this.warningLowContrast,
+        lowContrast: settingsStore.state.contrastWarning === 'on' && this.warningLowContrast,
         overflow: this.warningOverflow,
       },
       event: $event,
@@ -232,7 +232,7 @@ export class AppSlideWarning {
   }
 
   private renderMsg() {
-    if ((settingsStore.state.contrastWarning === 'on' && this.warningLowContrast) && this.warningOverflow) {
+    if (settingsStore.state.contrastWarning === 'on' && this.warningLowContrast && this.warningOverflow) {
       return (
         <ion-label>
           {i18n.state.warning.low_contrast} + {i18n.state.warning.overflow}

--- a/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
+++ b/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
@@ -205,7 +205,7 @@ export class AppSlideWarning {
     const popover: HTMLIonPopoverElement = await popoverController.create({
       component: 'app-slide-warning-info',
       componentProps: {
-        lowContrast: settingsStore.state.contrastWarning === 'on' && this.warningLowContrast,
+        lowContrast: settingsStore.state.contrastWarning && this.warningLowContrast,
         overflow: this.warningOverflow,
       },
       event: $event,
@@ -220,7 +220,7 @@ export class AppSlideWarning {
     return (
       <Host
         class={{
-          warning: (settingsStore.state.contrastWarning === 'on' && this.warningLowContrast) || this.warningOverflow,
+          warning: (settingsStore.state.contrastWarning && this.warningLowContrast) || this.warningOverflow,
         }}>
         <button class="ion-activatable" onClick={($event: UIEvent) => this.openInformation($event)}>
           <ion-ripple-effect></ion-ripple-effect>
@@ -232,13 +232,13 @@ export class AppSlideWarning {
   }
 
   private renderMsg() {
-    if (settingsStore.state.contrastWarning === 'on' && this.warningLowContrast && this.warningOverflow) {
+    if (settingsStore.state.contrastWarning && this.warningLowContrast && this.warningOverflow) {
       return (
         <ion-label>
           {i18n.state.warning.low_contrast} + {i18n.state.warning.overflow}
         </ion-label>
       );
-    } else if (settingsStore.state.contrastWarning === 'on' && this.warningLowContrast) {
+    } else if (settingsStore.state.contrastWarning && this.warningLowContrast) {
       return <ion-label>{i18n.state.warning.low_contrast}</ion-label>;
     } else if (this.warningOverflow) {
       return <ion-label>{i18n.state.warning.overflow}</ion-label>;

--- a/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
+++ b/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
@@ -6,6 +6,8 @@ import {debounce} from '@deckdeckgo/utils';
 
 import i18n from '../../../../stores/i18n.store';
 
+import settingsStore from '../../../../stores/settings.store';
+
 import {ContrastUtils} from '../../../../utils/editor/contrast.utils';
 import {NodeUtils} from '../../../../utils/editor/node.utils';
 import {SlotUtils} from '../../../../utils/editor/slot.utils';
@@ -22,14 +24,6 @@ export class AppSlideWarning {
 
   @State()
   private warningOverflow: boolean = false;
-
-  @State()
-  private checkLowContrast: boolean = true;
-
-  @Listen('deactivateContrastWarning', {target: 'document'})
-  onDeactivateContrastWarning() {
-    this.checkLowContrast = false;
-  }
 
   private readonly debounceResizeWarningOverflow: () => void = debounce(async () => {
     this.warningOverflow = await this.hasOverflow();
@@ -68,9 +62,7 @@ export class AppSlideWarning {
   }
 
   private async detectWarnings() {
-    if (this.checkLowContrast) {
-      this.warningLowContrast = await this.hasLowContrast();
-    }
+    this.warningLowContrast = await this.hasLowContrast();
     this.debounceResizeWarningOverflow();
   }
 
@@ -228,7 +220,7 @@ export class AppSlideWarning {
     return (
       <Host
         class={{
-          warning: (this.checkLowContrast && this.warningLowContrast) || this.warningOverflow,
+          warning: (settingsStore.state.contrastWarning === 'on' && this.warningLowContrast) || this.warningOverflow,
         }}>
         <button class="ion-activatable" onClick={($event: UIEvent) => this.openInformation($event)}>
           <ion-ripple-effect></ion-ripple-effect>
@@ -240,13 +232,13 @@ export class AppSlideWarning {
   }
 
   private renderMsg() {
-    if (this.warningLowContrast && this.warningOverflow) {
+    if ((settingsStore.state.contrastWarning === 'on' && this.warningLowContrast) && this.warningOverflow) {
       return (
         <ion-label>
           {i18n.state.warning.low_contrast} + {i18n.state.warning.overflow}
         </ion-label>
       );
-    } else if (this.warningLowContrast) {
+    } else if (settingsStore.state.contrastWarning === 'on' && this.warningLowContrast) {
       return <ion-label>{i18n.state.warning.low_contrast}</ion-label>;
     } else if (this.warningOverflow) {
       return <ion-label>{i18n.state.warning.overflow}</ion-label>;

--- a/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
+++ b/studio/src/app/components/editor/slide/app-slide-warning/app-slide-warning.tsx
@@ -23,6 +23,14 @@ export class AppSlideWarning {
   @State()
   private warningOverflow: boolean = false;
 
+  @State()
+  private checkLowContrast: boolean = true;
+
+  @Listen('deactivateContrastWarning', {target: 'document'})
+  onDeactivateContrastWarning() {
+    this.checkLowContrast = false;
+  }
+
   private readonly debounceResizeWarningOverflow: () => void = debounce(async () => {
     this.warningOverflow = await this.hasOverflow();
   }, 500);
@@ -60,7 +68,9 @@ export class AppSlideWarning {
   }
 
   private async detectWarnings() {
-    this.warningLowContrast = await this.hasLowContrast();
+    if (this.checkLowContrast) {
+      this.warningLowContrast = await this.hasLowContrast();
+    }
     this.debounceResizeWarningOverflow();
   }
 
@@ -218,7 +228,7 @@ export class AppSlideWarning {
     return (
       <Host
         class={{
-          warning: this.warningLowContrast || this.warningOverflow,
+          warning: (this.checkLowContrast && this.warningLowContrast) || this.warningOverflow,
         }}>
         <button class="ion-activatable" onClick={($event: UIEvent) => this.openInformation($event)}>
           <ion-ripple-effect></ion-ripple-effect>

--- a/studio/src/app/definitions/i18.d.ts
+++ b/studio/src/app/definitions/i18.d.ts
@@ -99,6 +99,7 @@ interface I18nSettings {
   contribute_community: string;
   contact: string;
   add_a_template: string;
+  deactivate_contrast_warning: string;
 }
 
 interface I18nDashboard {

--- a/studio/src/app/definitions/i18.d.ts
+++ b/studio/src/app/definitions/i18.d.ts
@@ -100,6 +100,9 @@ interface I18nSettings {
   contact: string;
   add_a_template: string;
   deactivate_contrast_warning: string;
+  contrast_warning: string;
+  contrast_warning_active: string;
+  contrast_warning_inactive: string;
 }
 
 interface I18nDashboard {

--- a/studio/src/app/pages/core/settings/app-customization/app-customization.tsx
+++ b/studio/src/app/pages/core/settings/app-customization/app-customization.tsx
@@ -6,7 +6,7 @@ import i18n from '../../../../stores/i18n.store';
 
 import {ThemeService} from '../../../../services/theme/theme.service';
 
-import {EditMode, ContrastWarning} from '../../../../types/core/settings';
+import {EditMode} from '../../../../types/core/settings';
 
 @Component({
   tag: 'app-customization',
@@ -17,7 +17,7 @@ export class AppCustomization {
 
   private editMode: EditMode = settingsStore.state.editMode;
 
-  private contrastWarning: ContrastWarning = settingsStore.state.contrastWarning;
+  private contrastWarning = settingsStore.state.contrastWarning;
 
   constructor() {
     this.themeService = ThemeService.getInstance();
@@ -36,7 +36,7 @@ export class AppCustomization {
   }
 
   private toggleContrastWarning() {
-    settingsStore.state.contrastWarning = settingsStore.state.contrastWarning === 'off' ? 'on' : 'off';
+    settingsStore.state.contrastWarning = !settingsStore.state.contrastWarning;
   }
 
   render() {
@@ -116,7 +116,7 @@ export class AppCustomization {
 
         <ion-select
           slot="end"
-          value={this.contrastWarning}
+          value={this.contrastWarning ? "on" : "off"}
           onIonChange={() => this.toggleContrastWarning()}
           interface="popover"
           mode="md"

--- a/studio/src/app/pages/core/settings/app-customization/app-customization.tsx
+++ b/studio/src/app/pages/core/settings/app-customization/app-customization.tsx
@@ -6,7 +6,7 @@ import i18n from '../../../../stores/i18n.store';
 
 import {ThemeService} from '../../../../services/theme/theme.service';
 
-import {EditMode} from '../../../../types/core/settings';
+import {EditMode, ContrastWarning} from '../../../../types/core/settings';
 
 @Component({
   tag: 'app-customization',
@@ -16,6 +16,8 @@ export class AppCustomization {
   private themeService: ThemeService;
 
   private editMode: EditMode = settingsStore.state.editMode;
+
+  private contrastWarning: ContrastWarning = settingsStore.state.contrastWarning;
 
   constructor() {
     this.themeService = ThemeService.getInstance();
@@ -33,6 +35,10 @@ export class AppCustomization {
     i18n.state.lang = $event.detail.value;
   }
 
+  private toggleContrastWarning() {
+    settingsStore.state.contrastWarning = settingsStore.state.contrastWarning === 'off' ? 'on' : 'off';
+  }
+
   render() {
     return [
       <app-navigation></app-navigation>,
@@ -46,6 +52,8 @@ export class AppCustomization {
             {this.renderLang()}
 
             {this.renderEditMode()}
+
+            {this.renderContrastWarning()}
           </ion-list>
         </main>
       </ion-content>,
@@ -96,6 +104,25 @@ export class AppCustomization {
           class="ion-padding-start ion-padding-end">
           <ion-select-option value="properties">{i18n.state.settings.properties}</ion-select-option>
           <ion-select-option value="css">CSS</ion-select-option>
+        </ion-select>
+      </ion-item>
+    );
+  }
+
+  private renderContrastWarning() {
+    return (
+      <ion-item>
+        <ion-label>{i18n.state.settings.contrast_warning}</ion-label>
+
+        <ion-select
+          slot="end"
+          value={this.contrastWarning}
+          onIonChange={() => this.toggleContrastWarning()}
+          interface="popover"
+          mode="md"
+          class="ion-padding-start ion-padding-end">
+          <ion-select-option value="on">{i18n.state.settings.contrast_warning_active}</ion-select-option>
+          <ion-select-option value="off">{i18n.state.settings.contrast_warning_inactive}</ion-select-option>
         </ion-select>
       </ion-item>
     );

--- a/studio/src/app/popovers/editor/app-slide-warning-info/app-slide-warning-info.tsx
+++ b/studio/src/app/popovers/editor/app-slide-warning-info/app-slide-warning-info.tsx
@@ -1,4 +1,4 @@
-import {Component, Element, Fragment, h, Prop} from '@stencil/core';
+import {Component, Element, Fragment, h, Prop, Event, EventEmitter} from '@stencil/core';
 
 import i18n from '../../../stores/i18n.store';
 import {renderI18n} from '../../../utils/core/i18n.utils';
@@ -15,8 +15,15 @@ export class AppSlideWarningInfo {
   @Prop()
   overflow: boolean;
 
+  @Event() deactivateContrastWarning: EventEmitter<boolean>;
+
   private async closePopover() {
     await (this.el.closest('ion-popover') as HTMLIonPopoverElement).dismiss();
+  }
+
+  private async setCheckContrastWarning() {
+    this.deactivateContrastWarning.emit(false);
+    await this.closePopover();
   }
 
   render() {
@@ -70,6 +77,11 @@ export class AppSlideWarningInfo {
         </p>
 
         <p>{i18n.state.warning.note}</p>
+        <div class="ion-text-center">
+          <ion-button size="small" shape="round" color="warning" onClick={() => this.setCheckContrastWarning()}>
+            {i18n.state.settings.deactivate_contrast_warning}
+          </ion-button>
+        </div>
       </Fragment>
     );
   }

--- a/studio/src/app/popovers/editor/app-slide-warning-info/app-slide-warning-info.tsx
+++ b/studio/src/app/popovers/editor/app-slide-warning-info/app-slide-warning-info.tsx
@@ -1,7 +1,9 @@
-import {Component, Element, Fragment, h, Prop, Event, EventEmitter} from '@stencil/core';
+import {Component, Element, Fragment, h, Prop} from '@stencil/core';
 
 import i18n from '../../../stores/i18n.store';
 import {renderI18n} from '../../../utils/core/i18n.utils';
+
+import settingsStore from '../../../stores/settings.store';
 
 @Component({
   tag: 'app-slide-warning-info',
@@ -15,15 +17,8 @@ export class AppSlideWarningInfo {
   @Prop()
   overflow: boolean;
 
-  @Event() deactivateContrastWarning: EventEmitter<boolean>;
-
   private async closePopover() {
     await (this.el.closest('ion-popover') as HTMLIonPopoverElement).dismiss();
-  }
-
-  private async setCheckContrastWarning() {
-    this.deactivateContrastWarning.emit(false);
-    await this.closePopover();
   }
 
   render() {
@@ -78,7 +73,13 @@ export class AppSlideWarningInfo {
 
         <p>{i18n.state.warning.note}</p>
         <div class="ion-text-center">
-          <ion-button size="small" shape="round" color="warning" onClick={() => this.setCheckContrastWarning()}>
+          <ion-button
+            size="small"
+            shape="round"
+            color="warning"
+            onClick={() => {
+              (settingsStore.state.contrastWarning = 'off'), this.closePopover();
+            }}>
             {i18n.state.settings.deactivate_contrast_warning}
           </ion-button>
         </div>

--- a/studio/src/app/popovers/editor/app-slide-warning-info/app-slide-warning-info.tsx
+++ b/studio/src/app/popovers/editor/app-slide-warning-info/app-slide-warning-info.tsx
@@ -78,7 +78,7 @@ export class AppSlideWarningInfo {
             shape="round"
             color="warning"
             onClick={() => {
-              (settingsStore.state.contrastWarning = 'off'), this.closePopover();
+              (settingsStore.state.contrastWarning = false), this.closePopover();
             }}>
             {i18n.state.settings.deactivate_contrast_warning}
           </ion-button>

--- a/studio/src/app/services/settings/settings.service.ts
+++ b/studio/src/app/services/settings/settings.service.ts
@@ -2,7 +2,7 @@ import settingsStore from '../../stores/settings.store';
 
 import {get} from 'idb-keyval';
 
-import {EditMode, SettingsPanels} from '../../types/core/settings';
+import {EditMode, SettingsPanels, ContrastWarning} from '../../types/core/settings';
 
 export class SettingsService {
   private static instance: SettingsService;
@@ -27,8 +27,10 @@ export class SettingsService {
       }
 
       const edit: EditMode | null = await get<EditMode>('deckdeckgo_settings_edit_mode');
+      const contrastWarning: ContrastWarning | null = await get<ContrastWarning>('deckdeckgo_settings_contrast_warning');
 
       settingsStore.state.editMode = edit ?? 'properties';
+      settingsStore.state.contrastWarning = contrastWarning ?? 'on';
     } catch (err) {
       console.warn(`Couldn't find settings for panels. Proceeding with default`);
     }

--- a/studio/src/app/services/settings/settings.service.ts
+++ b/studio/src/app/services/settings/settings.service.ts
@@ -2,7 +2,7 @@ import settingsStore from '../../stores/settings.store';
 
 import {get} from 'idb-keyval';
 
-import {EditMode, SettingsPanels, ContrastWarning} from '../../types/core/settings';
+import {EditMode, SettingsPanels} from '../../types/core/settings';
 
 export class SettingsService {
   private static instance: SettingsService;
@@ -27,10 +27,10 @@ export class SettingsService {
       }
 
       const edit: EditMode | null = await get<EditMode>('deckdeckgo_settings_edit_mode');
-      const contrastWarning: ContrastWarning | null = await get<ContrastWarning>('deckdeckgo_settings_contrast_warning');
+      const contrastWarning: boolean | null = await get<boolean>('deckdeckgo_settings_contrast_warning');
 
       settingsStore.state.editMode = edit ?? 'properties';
-      settingsStore.state.contrastWarning = contrastWarning ?? 'on';
+      settingsStore.state.contrastWarning = contrastWarning ?? true;
     } catch (err) {
       console.warn(`Couldn't find settings for panels. Proceeding with default`);
     }

--- a/studio/src/app/stores/settings.store.ts
+++ b/studio/src/app/stores/settings.store.ts
@@ -2,7 +2,7 @@ import {createStore} from '@stencil/store';
 
 import {set} from 'idb-keyval';
 
-import {EditMode, Settings, SettingsPanels, ContrastWarning} from '../types/core/settings';
+import {EditMode, Settings, SettingsPanels} from '../types/core/settings';
 
 const {state, onChange} = createStore<Settings>({
   panels: {
@@ -18,7 +18,7 @@ const {state, onChange} = createStore<Settings>({
     list: 'open',
   },
   editMode: 'properties',
-  contrastWarning: 'on',
+  contrastWarning: true,
 });
 
 onChange('panels', (panels: SettingsPanels) => {
@@ -33,7 +33,7 @@ onChange('editMode', (mode: EditMode) => {
   });
 });
 
-onChange('contrastWarning', (warningState: ContrastWarning) => {
+onChange('contrastWarning', (warningState) => {
   set('deckdeckgo_settings_contrast_warning', warningState).catch((err) => {
     console.error('Failed to update IDB with new edit mode', err);
   });

--- a/studio/src/app/stores/settings.store.ts
+++ b/studio/src/app/stores/settings.store.ts
@@ -2,7 +2,7 @@ import {createStore} from '@stencil/store';
 
 import {set} from 'idb-keyval';
 
-import {EditMode, Settings, SettingsPanels} from '../types/core/settings';
+import {EditMode, Settings, SettingsPanels, ContrastWarning} from '../types/core/settings';
 
 const {state, onChange} = createStore<Settings>({
   panels: {
@@ -18,6 +18,7 @@ const {state, onChange} = createStore<Settings>({
     list: 'open',
   },
   editMode: 'properties',
+  contrastWarning: 'on',
 });
 
 onChange('panels', (panels: SettingsPanels) => {
@@ -28,6 +29,12 @@ onChange('panels', (panels: SettingsPanels) => {
 
 onChange('editMode', (mode: EditMode) => {
   set('deckdeckgo_settings_edit_mode', mode).catch((err) => {
+    console.error('Failed to update IDB with new edit mode', err);
+  });
+});
+
+onChange('contrastWarning', (warningState: ContrastWarning) => {
+  set('deckdeckgo_settings_contrast_warning', warningState).catch((err) => {
     console.error('Failed to update IDB with new edit mode', err);
   });
 });

--- a/studio/src/app/types/core/settings.ts
+++ b/studio/src/app/types/core/settings.ts
@@ -2,8 +2,6 @@ export type Expanded = 'open' | 'close';
 
 export type EditMode = 'properties' | 'css';
 
-export type ContrastWarning = 'on' | 'off';
-
 export interface SettingsPanels {
   borderRadius: Expanded;
   boxShadow: Expanded;
@@ -20,5 +18,5 @@ export interface SettingsPanels {
 export interface Settings {
   panels: SettingsPanels;
   editMode: EditMode;
-  contrastWarning: ContrastWarning;
+  contrastWarning: boolean;
 }

--- a/studio/src/app/types/core/settings.ts
+++ b/studio/src/app/types/core/settings.ts
@@ -2,6 +2,8 @@ export type Expanded = 'open' | 'close';
 
 export type EditMode = 'properties' | 'css';
 
+export type ContrastWarning = 'on' | 'off';
+
 export interface SettingsPanels {
   borderRadius: Expanded;
   boxShadow: Expanded;
@@ -18,4 +20,5 @@ export interface SettingsPanels {
 export interface Settings {
   panels: SettingsPanels;
   editMode: EditMode;
+  contrastWarning: ContrastWarning;
 }

--- a/studio/src/assets/i18n/de.json
+++ b/studio/src/assets/i18n/de.json
@@ -94,7 +94,10 @@
     "contribute_community": "Möchtest du zur Community beitragen? {0} uns um eine Vorlage zu teilen.",
     "contact": "Kontakt",
     "add_a_template": "Füge eine Vorlage hinzu",
-    "deactivate_contrast_warning": "Deaktiviere Kontrast-Warnungen"
+    "deactivate_contrast_warning": "Deaktiviere Kontrast-Warnungen",
+    "contrast_warning": "Kontrast-Warnung",
+    "contrast_warning_active": "Ein",
+    "contrast_warning_inactive": "Aus"
   },
   "dashboard": {
     "welcome": "Willkommen bei DeckDeckGo 👋",

--- a/studio/src/assets/i18n/de.json
+++ b/studio/src/assets/i18n/de.json
@@ -93,7 +93,8 @@
     "custom_logo": "Benutzerdefiniertes Logo",
     "contribute_community": "Möchtest du zur Community beitragen? {0} uns um eine Vorlage zu teilen.",
     "contact": "Kontakt",
-    "add_a_template": "Füge eine Vorlage hinzu"
+    "add_a_template": "Füge eine Vorlage hinzu",
+    "deactivate_contrast_warning": "Deaktiviere Kontrast-Warnungen"
   },
   "dashboard": {
     "welcome": "Willkommen bei DeckDeckGo 👋",

--- a/studio/src/assets/i18n/en.json
+++ b/studio/src/assets/i18n/en.json
@@ -94,7 +94,10 @@
     "contribute_community": "Do you want to contribute to the community? {0} us to share a template.",
     "contact": "Contact",
     "add_a_template": "Add a template",
-    "deactivate_contrast_warning": "Deactivate low contrast warnings"
+    "deactivate_contrast_warning": "Deactivate low contrast warnings",
+    "contrast_warning": "Contrast warning",
+    "contrast_warning_active": "on",
+    "contrast_warning_inactive": "off"
   },
   "dashboard": {
     "welcome": "Welcome to DeckDeckGo 👋",

--- a/studio/src/assets/i18n/en.json
+++ b/studio/src/assets/i18n/en.json
@@ -93,7 +93,8 @@
     "custom_logo": "Custom logo",
     "contribute_community": "Do you want to contribute to the community? {0} us to share a template.",
     "contact": "Contact",
-    "add_a_template": "Add a template"
+    "add_a_template": "Add a template",
+    "deactivate_contrast_warning": "Deactivate low contrast warnings"
   },
   "dashboard": {
     "welcome": "Welcome to DeckDeckGo 👋",

--- a/studio/src/assets/i18n/es.json
+++ b/studio/src/assets/i18n/es.json
@@ -94,8 +94,8 @@
     "contribute_community": "¿Quieres contribuir a la comunidad? {0} para compartir una plantilla.",
     "contact": "Contactar",
     "add_a_template": "Añadir una plantilla",
-    "deactivate_contrast_warning": "Desactivar las advertencias de contraste",
-    "contrast_warning": "Advertencias de contraste",
+    "deactivate_contrast_warning": "Desactive la advertencia de contraste",
+    "contrast_warning": "Advertencia de contraste",
     "contrast_warning_active": "encendido",
     "contrast_warning_inactive": "apagado"
   },

--- a/studio/src/assets/i18n/es.json
+++ b/studio/src/assets/i18n/es.json
@@ -94,7 +94,10 @@
     "contribute_community": "¿Quieres contribuir a la comunidad? {0} para compartir una plantilla.",
     "contact": "Contactar",
     "add_a_template": "Añadir una plantilla",
-    "deactivate_contrast_warning": "Desactivar las advertencias de contraste"
+    "deactivate_contrast_warning": "Desactivar las advertencias de contraste",
+    "contrast_warning": "Advertencias de contraste",
+    "contrast_warning_active": "encendido",
+    "contrast_warning_inactive": "apagado"
   },
   "dashboard": {
     "welcome": "Bienvenido a DeckDeckGo 👋",

--- a/studio/src/assets/i18n/es.json
+++ b/studio/src/assets/i18n/es.json
@@ -93,7 +93,8 @@
     "custom_logo": "Logotipo personalizado",
     "contribute_community": "¿Quieres contribuir a la comunidad? {0} para compartir una plantilla.",
     "contact": "Contactar",
-    "add_a_template": "Añadir una plantilla"
+    "add_a_template": "Añadir una plantilla",
+    "deactivate_contrast_warning": "Desactivar las advertencias de contraste"
   },
   "dashboard": {
     "welcome": "Bienvenido a DeckDeckGo 👋",

--- a/studio/src/components.d.ts
+++ b/studio/src/components.d.ts
@@ -1666,6 +1666,7 @@ declare namespace LocalJSX {
     }
     interface AppSlideWarningInfo {
         "lowContrast"?: boolean;
+        "onDeactivateContrastWarning"?: (event: CustomEvent<boolean>) => void;
         "overflow"?: boolean;
     }
     interface AppSlotType {

--- a/studio/src/components.d.ts
+++ b/studio/src/components.d.ts
@@ -1666,7 +1666,6 @@ declare namespace LocalJSX {
     }
     interface AppSlideWarningInfo {
         "lowContrast"?: boolean;
-        "onDeactivateContrastWarning"?: (event: CustomEvent<boolean>) => void;
         "overflow"?: boolean;
     }
     interface AppSlotType {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `x` and remove the others. -->

- [x] Feature / Enhancement

## Other information

<!-- Please provide any useful other information. -->

Issue Number: #1064

Dismiss Low Contrast Warning in app-slide-warning and app-slide-warning-info

I added a new Button to the dialog that informs the user about low contrast on their slides (in app-slide-warning-info.tsx).
The Button closes the dialog and emits and event "deactivateContrastWarning", which is listened to in app-slide-warning.tsx

In app-slide-warning.tsx I added a State property "checkLowContrast" which is a boolean and defaults to `true`
When "deactivateContrastWarning" is caught in app-slide-warning.tsx, this.checkLowContrast will be set to `false`

I did not implement something in "settings > customization" yet, to activate contrast warnings again.

### Questions

I only tested manually, if the button works. After deactivation, the warning doesn't show up anymore on additional slides. But, when I reloaded the window, the state property "checkLowContrast" appears to be reset to its default (`true`). So the deactivation is not persistent.

I am opening this PR to get early feedback from you, David, to make sure I am on the right track. (I have no prior experience with Stencil)

Thank you for your feedback!