### PR TITLE
chore: add repository.directory for all packages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,11 @@
     "start": "node dist/index.js",
     "build": "rimraf dist && node ./esbuild.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/deckgo/deckdeckgo.git",
+    "directory": "cli"
+  },
   "files": [
     "dist/index.js",
     "README.md",

--- a/utils/deck/package.json
+++ b/utils/deck/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/deckgo/deckdeckgo.git"
+    "url": "git://github.com/deckgo/deckdeckgo.git",
+    "directory": "utils/deck"
   },
   "bugs": {
     "url": "https://github.com/deckgo/deckdeckgo"

--- a/utils/kit/package.json
+++ b/utils/kit/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/deckgo/deckdeckgo.git"
+    "url": "git://github.com/deckgo/deckdeckgo.git",
+    "directory": "utils/kit"
   },
   "bugs": {
     "url": "https://github.com/deckgo/deckdeckgo"

--- a/utils/remote/package.json
+++ b/utils/remote/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/deckgo/deckdeckgo.git"
+    "url": "git://github.com/deckgo/deckdeckgo.git",
+    "directory": "utils/remote"
   },
   "homepage": "https://deckdeckgo.com",
   "devDependencies": {

--- a/utils/slide/package.json
+++ b/utils/slide/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/deckgo/deckdeckgo.git"
+    "url": "git://github.com/deckgo/deckdeckgo.git",
+    "directory": "utils/slide"
   },
   "bugs": {
     "url": "https://github.com/deckgo/deckdeckgo"

--- a/utils/types/package.json
+++ b/utils/types/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/deckgo/deckdeckgo-types.git"
+    "url": "git://github.com/deckgo/deckdeckgo-types.git",
+    "directory": "utils/types"
   },
   "homepage": "https://deckdeckgo.com",
   "devDependencies": {

--- a/utils/utils/package.json
+++ b/utils/utils/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/deckgo/deckdeckgo.git"
+    "url": "git://github.com/deckgo/deckdeckgo.git",
+    "directory": "utils/utils"
   },
   "homepage": "https://deckdeckgo.com",
   "devDependencies": {

--- a/webcomponents/charts/package.json
+++ b/webcomponents/charts/package.json
@@ -53,7 +53,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/charts"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/color/package.json
+++ b/webcomponents/color/package.json
@@ -35,7 +35,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/color"
   },
   "author": "David Dal Busco",
   "bugs": {

--- a/webcomponents/core/package.json
+++ b/webcomponents/core/package.json
@@ -38,7 +38,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/core"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/demo/package.json
+++ b/webcomponents/demo/package.json
@@ -41,7 +41,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/demo"
   },
   "author": "David Dal Busco",
   "bugs": {

--- a/webcomponents/drag-resize-rotate/package.json
+++ b/webcomponents/drag-resize-rotate/package.json
@@ -42,7 +42,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/drag-resize-rotate"
   },
   "author": "David Dal Busco",
   "bugs": {

--- a/webcomponents/highlight-code/package.json
+++ b/webcomponents/highlight-code/package.json
@@ -42,7 +42,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/highlight-code"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/inline-editor/package.json
+++ b/webcomponents/inline-editor/package.json
@@ -38,7 +38,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/inline-editor"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/laser-pointer/package.json
+++ b/webcomponents/laser-pointer/package.json
@@ -35,7 +35,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/laser-pointer"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/lazy-img/package.json
+++ b/webcomponents/lazy-img/package.json
@@ -36,7 +36,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/lazy-img"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/markdown/package.json
+++ b/webcomponents/markdown/package.json
@@ -40,7 +40,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/markdown"
   },
   "author": "Christian Petro",
   "license": "MIT",

--- a/webcomponents/math/package.json
+++ b/webcomponents/math/package.json
@@ -39,7 +39,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/math"
   },
   "author": "Akash Borad",
   "bugs": {

--- a/webcomponents/pager/package.json
+++ b/webcomponents/pager/package.json
@@ -35,7 +35,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/pager"
   },
   "author": "David Dal Busco",
   "bugs": {

--- a/webcomponents/qrcode/package.json
+++ b/webcomponents/qrcode/package.json
@@ -35,7 +35,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo-qrcode.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo-qrcode.git",
+    "directory": "webcomponents/qrcode"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/remote/package.json
+++ b/webcomponents/remote/package.json
@@ -43,7 +43,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo-remote.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo-remote.git",
+    "directory": "webcomponents/remote"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/reveal/package.json
+++ b/webcomponents/reveal/package.json
@@ -34,7 +34,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/reveal"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/aspect-ratio/package.json
+++ b/webcomponents/slides/aspect-ratio/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/aspect-ratio"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/author/package.json
+++ b/webcomponents/slides/author/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/author"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/chart/package.json
+++ b/webcomponents/slides/chart/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/chart"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/content/package.json
+++ b/webcomponents/slides/content/package.json
@@ -36,7 +36,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/content"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/gif/package.json
+++ b/webcomponents/slides/gif/package.json
@@ -36,7 +36,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/gif"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/playground/package.json
+++ b/webcomponents/slides/playground/package.json
@@ -42,7 +42,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/playground"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/poll/package.json
+++ b/webcomponents/slides/poll/package.json
@@ -45,7 +45,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/poll"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/qrcode/package.json
+++ b/webcomponents/slides/qrcode/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/qrcode"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/split/package.json
+++ b/webcomponents/slides/split/package.json
@@ -36,7 +36,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/split"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/title/package.json
+++ b/webcomponents/slides/title/package.json
@@ -36,7 +36,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/title"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/slides/youtube/package.json
+++ b/webcomponents/slides/youtube/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/slides/youtube"
   },
   "author": "David Dal Busco",
   "license": "MIT",

--- a/webcomponents/social/package.json
+++ b/webcomponents/social/package.json
@@ -41,7 +41,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/social"
   },
   "author": "David Dal Busco",
   "bugs": {

--- a/webcomponents/word-cloud/package.json
+++ b/webcomponents/word-cloud/package.json
@@ -42,7 +42,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/word-cloud"
   },
   "author": "Achilles Moraites",
   "bugs": {

--- a/webcomponents/youtube/package.json
+++ b/webcomponents/youtube/package.json
@@ -41,7 +41,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deckgo/deckdeckgo.git"
+    "url": "git+https://github.com/deckgo/deckdeckgo.git",
+    "directory": "webcomponents/youtube"
   },
   "author": "David Dal Busco",
   "bugs": {


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives


<details>
<summary>made the changes with a script to make my life easier 🙂 </summary>

```js
const { readdirSync, readFileSync, writeFileSync } = require("fs");
const { resolve } = require("path");

const folders = ["utils", "webcomponents", "webcomponents/slides"];

folders.forEach((folder) => {
  readdirSync(folder).forEach((dir) => {
    const path = resolve(process.cwd(), folder, dir, "package.json");
    try {
      const package = require(path);
      if (typeof package.repository === 'object') {
        package.repository.directory = `${folder}/${dir}`;
        writeFileSync(path, JSON.stringify(package, null, 2) + "\n");
      }
    } catch (e) {}
  });
});
```

</details>
