### PR TITLE
fix(i18n): translate settings in menu

### DIFF
--- a/studio/src/app/components/core/app-menu/app-menu.tsx
+++ b/studio/src/app/components/core/app-menu/app-menu.tsx
@@ -104,7 +104,7 @@ export class AppMenu {
 
     return (
       <app-expansion-panel expanded="close">
-        <ion-label slot="title">Settings</ion-label>
+        <ion-label slot="title">{i18n.state.nav.settings}</ion-label>
         <AppIcon name="settings" ariaLabel="" ariaHidden={true} lazy={true} slot="icon"></AppIcon>
 
         <ion-list class="settings">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Other information

When checking out the new Dutch translations (congratulations on version 5!), I found out that 'Settings' in the left menu is hardcoded, and not derived from i18n translations. It was already there for a long time.
