### PR TITLE
fix: publish firebase owner_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="5.x.0"></a>
+
+# [5.X.0](https://github.com/deckgo/deckdeckgo/compare/v5.2.0...v5.X.0) (2022-AA-BB)
+
+### Providers
+
+- firebase: v3.0.1 ([CHANGELOG](https://github.com/deckgo/deckdeckgo/blob/main/providers/firebase/CHANGELOG.md))
+
 <a name="5.2.0"></a>
 
 # [5.2.0](https://github.com/deckgo/deckdeckgo/compare/v5.1.0...v5.2.0) (2021-12-24)

--- a/providers/firebase/CHANGELOG.md
+++ b/providers/firebase/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.1 (2022-01-04)
+
+### Fix
+
+- `owner_id` might not been set in the provided data to publish
+
 # 3.0.0 (2021-11-27)
 
 ### Breaking Changes

--- a/providers/firebase/package.json
+++ b/providers/firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deckdeckgo/firebase",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The Firebase connectors of the DeckDeckGo editor for slides",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/studio/src/app/providers/publish/publish.provider.ts
+++ b/studio/src/app/providers/publish/publish.provider.ts
@@ -103,6 +103,11 @@ const updateDeckMeta = (inputs: PublishInputs): Deck => {
     }
   }
 
+  // TODO: FIXME
+  if (deck.data.owner_id === undefined && authStore.state.loggedIn) {
+    deck.data.owner_id = authStore.state.authUser?.uid;
+  }
+
   return deck;
 };
 

--- a/studio/src/global/app-staging.ts
+++ b/studio/src/global/app-staging.ts
@@ -70,10 +70,10 @@ setupDeckGoConfig({
   },
   cloud: {
     api: {
-      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.0/dist/deckdeckgo-firebase/index.esm.js'
+      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.1/dist/deckdeckgo-firebase/index.esm.js'
     },
     signIn: {
-      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.0/dist/deckdeckgo-firebase/deckdeckgo-firebase.esm.js',
+      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.1/dist/deckdeckgo-firebase/deckdeckgo-firebase.esm.js',
       tag: 'deckgo-firebase-signin'
     }
   }

--- a/studio/src/global/app.ts
+++ b/studio/src/global/app.ts
@@ -70,10 +70,10 @@ setupDeckGoConfig({
   },
   cloud: {
     api: {
-      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.0/dist/deckdeckgo-firebase/index.esm.js'
+      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.1/dist/deckdeckgo-firebase/index.esm.js'
     },
     signIn: {
-      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.0/dist/deckdeckgo-firebase/deckdeckgo-firebase.esm.js',
+      cdn: 'https://unpkg.com/@deckdeckgo/firebase@3.0.1/dist/deckdeckgo-firebase/deckdeckgo-firebase.esm.js',
       tag: 'deckgo-firebase-signin'
     }
   }


### PR DESCRIPTION
If a deck is created offline before the user sign it, it will be added to indexedDB without `owner_id` field.
This field will not be updated unless the all deck is reloaded from the cloud (through the "presentations" page).
When the sync with the cloud happens, the firebase providers takes care to update the field before updating the cloud.

At publish / share time, this update was missing.